### PR TITLE
Patch to possibly add threading headers to cyclestreets mails

### DIFF
--- a/app/mailers/thread_mailer.rb
+++ b/app/mailers/thread_mailer.rb
@@ -38,6 +38,7 @@ class ThreadMailer < ActionMailer::Base
     mail(to: subscriber.name_with_email,
          subject: t("mailers.thread_mailer.common.subject", title: @thread.title, count: @thread.message_count),
          from: email_from,
+         references: reply_to,
          reply_to: reply_to)
   end
 end


### PR DESCRIPTION
include a References header to be the same as the reply_to address, which is a valid email address for that thread. Will do basic threading.

Ideally the message ID would be populated here, and would take the message-in-thread-number that comes in far higher up in the call change, and do <msg-number>-<threadid>@domain so we get predictable msgids, and can then add the References programatically.
