### PR TITLE
ensure even erroneous processed mail is marked seen

### DIFF
--- a/lib/mailbox_reader.rb
+++ b/lib/mailbox_reader.rb
@@ -4,14 +4,17 @@ class MailboxReader < MailboxProcessor
   def run
     begin
       fetch_message_ids(config[:mailbox]).each do |mid|
-        # Fetch message from IMAP server
-        message = fetch_raw_message(mid)
-        # Save to database
-        ar_message = save_message(message)
-        # Mark message as read in IMAP mailbox
-        mark_as_seen(mid)
-        # Send to the mail processor
-        enqueue(ar_message)
+        begin
+          # Fetch message from IMAP server
+          message = fetch_raw_message(mid)
+          # Save to database
+          ar_message = save_message(message)
+          # Send to the mail processor
+          enqueue(ar_message)
+        ensure
+          # Mark message as read in IMAP mailbox
+          mark_as_seen(mid)
+        end
       end
     ensure
       disconnect

--- a/vendor/assets/javascripts/jquery.tools.min.js
+++ b/vendor/assets/javascripts/jquery.tools.min.js
@@ -10,7 +10,7 @@
  * tooltip/tooltip.js
  *
  * NO COPYRIGHTS OR LICENSES. DO WHAT YOU LIKE.
- * This file has been altered by CycleScape in 
+ * This file has been altered by CycleScape in 5d51955
  *
  * http://flowplayer.org/tools/
  *


### PR DESCRIPTION
Fixes #231 so that we ensure that even if an email fails to parse (because of malformed headers etc.) then it is marked as seen on the server.  An error will still be thrown (and an email generated) but the next time the job is scheduled (5 mins later) the email will [not be fetched](https://github.com/cyclestreets/cyclescape/blob/master/lib/mailbox_processor.rb#L36) as it will be marked as seen.