### PR TITLE
Email threading

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -10,6 +10,11 @@ module MailerHelper
     "<message-#{message.public_token}@#{domain}>"
   end
 
+  def message_chain(message)
+    return "" unless message
+    "#{message_chain(message.in_reply_to)} #{message_address(message)}".strip
+  end
+
   # Notifications are sent from a fixed email but with different names
   def user_notification_address(user)
     ['"', user.name, '" <notifications@', domain, '>'].join

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -4,15 +4,20 @@ module MailerHelper
     Rails.application.config.default_email_from_domain
   end
 
+  # Deprecated
+  def thread_address(thread)
+    "<thread-#{thread.public_token}@#{domain}>"
+  end
+
   # Message-specific email address
   # No name in the address to stop it being added to automatic client address books
   def message_address(message)
     "<message-#{message.public_token}@#{domain}>"
   end
 
-  def message_chain(message)
-    return "" unless message
-    "#{message_chain(message.in_reply_to)} #{message_address(message)}".strip
+  def message_chain(message, thread)
+    return thread_address(thread) unless message
+    "#{message_chain(message.in_reply_to, thread)} #{message_address(message)}".strip
   end
 
   # Notifications are sent from a fixed email but with different names

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -4,10 +4,10 @@ module MailerHelper
     Rails.application.config.default_email_from_domain
   end
 
-  # Thread-specific email address
+  # Message-specific email address
   # No name in the address to stop it being added to automatic client address books
-  def thread_address(thread)
-    "<thread-#{thread.public_token}@#{domain}>"
+  def message_address(message)
+    "<message-#{message.public_token}@#{domain}>"
   end
 
   # Notifications are sent from a fixed email but with different names

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -57,12 +57,13 @@ class Notifications < ActionMailer::Base
   def new_group_thread(thread, member)
     @thread = thread
     @group = thread.group
-    @message_author = thread.first_message.created_by
+    message = thread.first_message
+    @message_author = message.created_by
     @member = member
     fail 'Thread does not belong to group' if @group.nil?
     mail to: @member.name_with_email,
          from: user_notification_address(@message_author),
-         reply_to: thread_address(@thread),
+         reply_to: message_address(message),
          subject: t('mailers.notifications.new_group_thread.subject',
                     group_name: @group.name, thread_title: @thread.title)
   end
@@ -85,7 +86,7 @@ class Notifications < ActionMailer::Base
     fail 'Thread does not have an issue' unless @thread.issue
     mail to: @user.name_with_email,
          from: user_notification_address(@message.created_by),
-         reply_to: thread_address(@thread),
+         reply_to: message_address(@message),
          subject: t('mailers.notifications.new_user_location_issue_thread.subject',
                     issue_title: @thread.issue.title)
   end

--- a/app/mailers/thread_mailer.rb
+++ b/app/mailers/thread_mailer.rb
@@ -18,11 +18,11 @@ class ThreadMailer < ActionMailer::Base
     @thread = message.thread
     @subscriber = subscriber
     email_from = user_notification_address(message.created_by)
-    reply_to = message_address(@message)
+
     mail(to: subscriber.name_with_email,
          subject: t('mailers.thread_mailer.common.subject', title: @thread.title, count: @thread.message_count),
          from: email_from,
-         references: reply_to,
-         reply_to: reply_to)
+         references: message_chain(@message.in_reply_to),
+         reply_to: message_address(@message))
   end
 end

--- a/app/mailers/thread_mailer.rb
+++ b/app/mailers/thread_mailer.rb
@@ -18,7 +18,7 @@ class ThreadMailer < ActionMailer::Base
     @thread = message.thread
     @subscriber = subscriber
     email_from = user_notification_address(message.created_by)
-    reply_to = thread_address(@thread)
+    reply_to = message_address(@message)
     mail(to: subscriber.name_with_email,
          subject: t('mailers.thread_mailer.common.subject', title: @thread.title, count: @thread.message_count),
          from: email_from,

--- a/app/mailers/thread_mailer.rb
+++ b/app/mailers/thread_mailer.rb
@@ -22,8 +22,8 @@ class ThreadMailer < ActionMailer::Base
     mail(to: subscriber.name_with_email,
          subject: t('mailers.thread_mailer.common.subject', title: @thread.title, count: @thread.message_count),
          from: email_from,
-         references: message_chain(@message.in_reply_to),
+         references: message_chain(@message.in_reply_to, @thread),
          message_id: message_address(@message),
-         reply_to: message_address(@message))
+         in_reply_to: thread_address(@thread))
   end
 end

--- a/app/mailers/thread_mailer.rb
+++ b/app/mailers/thread_mailer.rb
@@ -23,6 +23,7 @@ class ThreadMailer < ActionMailer::Base
          subject: t('mailers.thread_mailer.common.subject', title: @thread.title, count: @thread.message_count),
          from: email_from,
          references: message_chain(@message.in_reply_to),
+         message_id: message_address(@message),
          reply_to: message_address(@message))
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -68,7 +68,7 @@ class Message < ActiveRecord::Base
   end
 
   def set_in_reply_to
-    self.in_reply_to_id ||= thread.messages.last.try(:id)
+    self.in_reply_to ||= thread.messages.last
   end
 
   def set_public_token

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -37,6 +37,7 @@ class Message < ActiveRecord::Base
 
   validates :created_by_id, presence: true
   validates :body, presence: true, unless: :component
+  validate  :in_reply_to_should_belong_to_same_thread
 
   def censor!
     self.censored_at = Time.now
@@ -67,10 +68,15 @@ class Message < ActiveRecord::Base
   end
 
   def set_in_reply_to
-    self.in_reply_to = thread.messages.last
+    self.in_reply_to_id ||= thread.messages.last.try(:id)
   end
 
   def set_public_token
     self.public_token = SecureRandom.hex(10)
+  end
+
+  def in_reply_to_should_belong_to_same_thread
+    return unless in_reply_to
+    errors.add :in_reply_to_id, :invalid unless in_reply_to.thread.id == thread.id
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -25,10 +25,13 @@ class Message < ActiveRecord::Base
   belongs_to :thread, class_name: 'MessageThread'
   belongs_to :created_by, class_name: 'User'
   belongs_to :component, polymorphic: true, autosave: true
+  belongs_to :in_reply_to, class_name: 'Message'
 
   before_validation :init_blank_body, on: :create, if: :component
+  before_validation :set_public_token, on: :create
 
-  after_save :update_thread_search
+  before_save :set_in_reply_to
+  after_save  :update_thread_search
 
   scope :recent, -> { order('created_at DESC').limit(3) }
 
@@ -61,5 +64,13 @@ class Message < ActiveRecord::Base
 
   def init_blank_body
     self.body ||= ''
+  end
+
+  def set_in_reply_to
+    self.in_reply_to = thread.messages.last
+  end
+
+  def set_public_token
+    self.public_token = SecureRandom.hex(10)
   end
 end

--- a/app/models/message_thread.rb
+++ b/app/models/message_thread.rb
@@ -93,7 +93,7 @@ class MessageThread < ActiveRecord::Base
     end
   end
 
-  def add_messages_from_email!(mail)
+  def add_messages_from_email!(mail, in_reply_to)
     from_address = mail.message.header[:from].addresses.first
     from_name = mail.message.header[:from].display_names.first
 
@@ -112,7 +112,7 @@ class MessageThread < ActiveRecord::Base
 
     m = []
 
-    m << messages.create!( body: stripped, created_by: user )
+    m << messages.create!(body: stripped, created_by: user, in_reply_to: in_reply_to)
 
     # Attachments
     mail.message.attachments.each do |attachment|
@@ -121,11 +121,11 @@ class MessageThread < ActiveRecord::Base
       else
         component = DocumentMessage.new(file: attachment.body.decoded, title: attachment.filename)
       end
-      message = messages.build( created_by: user )
-      component.thread = self
-      component.message = message
+      message              = messages.build(created_by: user, in_reply_to: in_reply_to)
+      component.thread     = self
+      component.message    = message
       component.created_by = user
-      message.component = component
+      message.component    = component
       message.save!
       m << message
     end

--- a/app/workers/inbound_mail_processor.rb
+++ b/app/workers/inbound_mail_processor.rb
@@ -5,20 +5,26 @@ class InboundMailProcessor
 
   def self.perform(mail_id)
     mail = InboundMail.find(mail_id)
-    if mail.message.to.first.match(/^thread-([^@]+)/)
-      deliver_thread_reply(mail, Regexp.last_match[1])
-    end
+    to_address = mail.message.to.first
+    thread_match = to_address.match(/^thread-([^@]+)/)
+    message_match = to_address.match(/^message-([^@]+)/)
+    deliver_thread_reply(mail, thread_match.try(:[], 1), message_match.try(:[], 1))
   end
 
-  def self.deliver_thread_reply(mail, thread_token)
-    thread = MessageThread.find_by_public_token(thread_token)
-    fail "Thread #{thread_token.inspect} not found" if thread.nil?
+  def self.deliver_thread_reply(mail, thread_token, message_token)
+    message = Message.find_by(public_token: message_token)
+    thread = if message
+               message.thread
+             else
+               MessageThread.find_by(public_token: thread_token)
+             end
+    fail "Message #{message_token.inspect} and thread #{thread_token.inspect} not found" unless thread || message
 
     # This raises an exception if it fails
-    messages = thread.add_messages_from_email!(mail)
+    messages = thread.add_messages_from_email!(mail, message)
     thread.add_subscriber(messages.first.created_by) unless messages.first.created_by.ever_subscribed_to_thread?(thread)
-    messages.each do |message|
-      ThreadNotifier.notify_subscribers(thread, ['new', message.component_name].join('_').to_sym, message)
+    messages.each do |mess|
+      ThreadNotifier.notify_subscribers(thread, ['new', mess.component_name].join('_').to_sym, mess)
     end
   end
 end

--- a/db/migrate/20151012193545_add_in_reply_to_to_messages.rb
+++ b/db/migrate/20151012193545_add_in_reply_to_to_messages.rb
@@ -1,0 +1,5 @@
+class AddInReplyToToMessages < ActiveRecord::Migration
+  def change
+    add_reference :messages, :in_reply_to, index: true
+  end
+end

--- a/db/migrate/20151012194550_add_public_token_to_messages.rb
+++ b/db/migrate/20151012194550_add_public_token_to_messages.rb
@@ -1,6 +1,10 @@
 class AddPublicTokenToMessages < ActiveRecord::Migration
   def change
     add_column :messages, :public_token, :string
+    Message.find_each do |message|
+      message.update_column(:public_token, SecureRandom.hex(10))
+    end
+    change_column :messages, :public_token, :string, null: false
     add_index :messages, :public_token, unique: true
   end
 end

--- a/db/migrate/20151012194550_add_public_token_to_messages.rb
+++ b/db/migrate/20151012194550_add_public_token_to_messages.rb
@@ -1,0 +1,6 @@
+class AddPublicTokenToMessages < ActiveRecord::Migration
+  def change
+    add_column :messages, :public_token, :string
+    add_index :messages, :public_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,59 +11,59 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150831090642) do
+ActiveRecord::Schema.define(version: 20151012194550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
 
-  create_table "deadline_messages", force: true do |t|
-    t.integer  "thread_id",         null: false
-    t.integer  "message_id",        null: false
-    t.integer  "created_by_id",     null: false
-    t.datetime "deadline",          null: false
-    t.string   "title",             null: false
+  create_table "deadline_messages", force: :cascade do |t|
+    t.integer  "thread_id",                     null: false
+    t.integer  "message_id",                    null: false
+    t.integer  "created_by_id",                 null: false
+    t.datetime "deadline",                      null: false
+    t.string   "title",             limit: 255, null: false
     t.datetime "created_at"
     t.datetime "invalidated_at"
     t.integer  "invalidated_by_id"
   end
 
-  create_table "document_messages", force: true do |t|
-    t.integer "thread_id",     null: false
-    t.integer "message_id",    null: false
-    t.integer "created_by_id", null: false
-    t.string  "title",         null: false
-    t.string  "file_uid"
-    t.string  "file_name"
+  create_table "document_messages", force: :cascade do |t|
+    t.integer "thread_id",                 null: false
+    t.integer "message_id",                null: false
+    t.integer "created_by_id",             null: false
+    t.string  "title",         limit: 255, null: false
+    t.string  "file_uid",      limit: 255
+    t.string  "file_name",     limit: 255
     t.integer "file_size"
   end
 
-  create_table "group_membership_requests", force: true do |t|
-    t.integer  "user_id",        null: false
-    t.integer  "group_id",       null: false
-    t.string   "status",         null: false
+  create_table "group_membership_requests", force: :cascade do |t|
+    t.integer  "user_id",                    null: false
+    t.integer  "group_id",                   null: false
+    t.string   "status",         limit: 255, null: false
     t.integer  "actioned_by_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "message"
   end
 
-  add_index "group_membership_requests", ["group_id"], :name => "index_group_membership_requests_on_group_id"
-  add_index "group_membership_requests", ["user_id"], :name => "index_group_membership_requests_on_user_id"
+  add_index "group_membership_requests", ["group_id"], name: "index_group_membership_requests_on_group_id", using: :btree
+  add_index "group_membership_requests", ["user_id"], name: "index_group_membership_requests_on_user_id", using: :btree
 
-  create_table "group_memberships", force: true do |t|
-    t.integer  "user_id",    null: false
-    t.integer  "group_id",   null: false
-    t.string   "role",       null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "group_memberships", force: :cascade do |t|
+    t.integer  "user_id",                null: false
+    t.integer  "group_id",               null: false
+    t.string   "role",       limit: 255, null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
     t.datetime "deleted_at"
   end
 
-  add_index "group_memberships", ["group_id"], :name => "index_group_memberships_on_group_id"
-  add_index "group_memberships", ["user_id"], :name => "index_group_memberships_on_user_id"
+  add_index "group_memberships", ["group_id"], name: "index_group_memberships_on_group_id", using: :btree
+  add_index "group_memberships", ["user_id"], name: "index_group_memberships_on_user_id", using: :btree
 
-  create_table "group_prefs", force: true do |t|
+  create_table "group_prefs", force: :cascade do |t|
     t.integer  "group_id",                                  null: false
     t.integer  "membership_secretary_id"
     t.boolean  "notify_membership_requests", default: true, null: false
@@ -71,233 +71,237 @@ ActiveRecord::Schema.define(version: 20150831090642) do
     t.datetime "updated_at",                                null: false
   end
 
-  add_index "group_prefs", ["group_id"], :name => "index_group_prefs_on_group_id", :unique => true
+  add_index "group_prefs", ["group_id"], name: "index_group_prefs_on_group_id", unique: true, using: :btree
 
-  create_table "group_profiles", force: true do |t|
+  create_table "group_profiles", force: :cascade do |t|
     t.integer  "group_id",                                                      null: false
     t.text     "description"
     t.datetime "created_at",                                                    null: false
     t.datetime "updated_at",                                                    null: false
-    t.spatial  "location",             limit: {:srid=>4326, :type=>"geometry"}
+    t.geometry "location",             limit: {:srid=>4326, :type=>"geometry"}
     t.text     "joining_instructions"
-    t.string   "picture_uid"
-    t.string   "picture_name"
+    t.string   "picture_uid",          limit: 255
+    t.string   "picture_name",         limit: 255
   end
 
-  add_index "group_profiles", ["group_id"], :name => "index_group_profiles_on_group_id"
-  add_index "group_profiles", ["location"], :name => "index_group_profiles_on_location", :spatial => true
+  add_index "group_profiles", ["group_id"], name: "index_group_profiles_on_group_id", using: :btree
+  add_index "group_profiles", ["location"], name: "index_group_profiles_on_location", using: :gist
 
-  create_table "group_requests", force: true do |t|
-    t.string   "status"
-    t.integer  "user_id",                                   null: false
+  create_table "group_requests", force: :cascade do |t|
+    t.string   "status",                 limit: 255
+    t.integer  "user_id",                                               null: false
     t.integer  "actioned_by_id"
-    t.string   "name",                                      null: false
-    t.string   "short_name",                                null: false
-    t.string   "default_thread_privacy", default: "public", null: false
-    t.string   "website"
-    t.string   "email",                                     null: false
+    t.string   "name",                   limit: 255,                    null: false
+    t.string   "short_name",             limit: 255,                    null: false
+    t.string   "default_thread_privacy", limit: 255, default: "public", null: false
+    t.string   "website",                limit: 255
+    t.string   "email",                  limit: 255,                    null: false
     t.text     "message"
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
+    t.datetime "created_at",                                            null: false
+    t.datetime "updated_at",                                            null: false
     t.text     "rejection_message"
   end
 
-  add_index "group_requests", ["name"], :name => "index_group_requests_on_name", :unique => true
-  add_index "group_requests", ["short_name"], :name => "index_group_requests_on_short_name", :unique => true
-  add_index "group_requests", ["user_id"], :name => "index_group_requests_on_user_id"
+  add_index "group_requests", ["name"], name: "index_group_requests_on_name", unique: true, using: :btree
+  add_index "group_requests", ["short_name"], name: "index_group_requests_on_short_name", unique: true, using: :btree
+  add_index "group_requests", ["user_id"], name: "index_group_requests_on_user_id", using: :btree
 
-  create_table "groups", force: true do |t|
-    t.string   "name",                                      null: false
-    t.string   "short_name",                                null: false
-    t.string   "website"
-    t.string   "email"
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
+  create_table "groups", force: :cascade do |t|
+    t.string   "name",                   limit: 255,                    null: false
+    t.string   "short_name",             limit: 255,                    null: false
+    t.string   "website",                limit: 255
+    t.string   "email",                  limit: 255
+    t.datetime "created_at",                                            null: false
+    t.datetime "updated_at",                                            null: false
     t.datetime "disabled_at"
-    t.string   "default_thread_privacy", default: "public", null: false
+    t.string   "default_thread_privacy", limit: 255, default: "public", null: false
   end
 
-  add_index "groups", ["short_name"], :name => "index_groups_on_short_name"
+  add_index "groups", ["short_name"], name: "index_groups_on_short_name", using: :btree
 
-  create_table "hide_votes", force: true do |t|
+  create_table "hide_votes", force: :cascade do |t|
     t.integer  "planning_application_id"
     t.integer  "user_id"
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
   end
 
-  add_index "hide_votes", ["planning_application_id", "user_id"], :name => "index_hide_votes_on_planning_application_id_and_user_id", :unique => true
+  add_index "hide_votes", ["planning_application_id", "user_id"], name: "index_hide_votes_on_planning_application_id_and_user_id", unique: true, using: :btree
 
-  create_table "inbound_mails", force: true do |t|
-    t.string   "recipient",                     null: false
-    t.text     "raw_message",                   null: false
-    t.datetime "created_at",                    null: false
+  create_table "inbound_mails", force: :cascade do |t|
+    t.string   "recipient",     limit: 255,                 null: false
+    t.text     "raw_message",                               null: false
+    t.datetime "created_at",                                null: false
     t.datetime "processed_at"
-    t.boolean  "process_error", default: false, null: false
+    t.boolean  "process_error",             default: false, null: false
   end
 
-  create_table "issue_tags", id: false, force: true do |t|
+  create_table "issue_tags", id: false, force: :cascade do |t|
     t.integer "issue_id", null: false
     t.integer "tag_id",   null: false
   end
 
-  add_index "issue_tags", ["issue_id", "tag_id"], :name => "index_issue_tags_on_issue_id_and_tag_id", :unique => true
+  add_index "issue_tags", ["issue_id", "tag_id"], name: "index_issue_tags_on_issue_id_and_tag_id", unique: true, using: :btree
 
-  create_table "issues", force: true do |t|
+  create_table "issues", force: :cascade do |t|
     t.integer  "created_by_id",                                          null: false
-    t.string   "title",                                                  null: false
+    t.string   "title",         limit: 255,                              null: false
     t.text     "description",                                            null: false
     t.datetime "created_at",                                             null: false
     t.datetime "updated_at",                                             null: false
     t.datetime "deleted_at"
-    t.spatial  "location",      limit: {:srid=>4326, :type=>"geometry"}
-    t.string   "photo_uid"
+    t.geometry "location",      limit: {:srid=>4326, :type=>"geometry"}
+    t.string   "photo_uid",     limit: 255
     t.datetime "deadline"
-    t.string   "external_url"
+    t.string   "external_url",  limit: 255
   end
 
-  add_index "issues", ["created_by_id"], :name => "index_issues_on_created_by_id"
-  add_index "issues", ["location"], :name => "index_issues_on_location", :spatial => true
+  add_index "issues", ["created_by_id"], name: "index_issues_on_created_by_id", using: :btree
+  add_index "issues", ["location"], name: "index_issues_on_location", using: :gist
 
-  create_table "library_documents", force: true do |t|
-    t.integer "library_item_id", null: false
-    t.string  "title",           null: false
-    t.string  "file_uid"
-    t.string  "file_name"
+  create_table "library_documents", force: :cascade do |t|
+    t.integer "library_item_id",             null: false
+    t.string  "title",           limit: 255, null: false
+    t.string  "file_uid",        limit: 255
+    t.string  "file_name",       limit: 255
     t.integer "file_size"
   end
 
-  create_table "library_item_messages", force: true do |t|
+  create_table "library_item_messages", force: :cascade do |t|
     t.integer "thread_id",       null: false
     t.integer "message_id",      null: false
     t.integer "library_item_id", null: false
     t.integer "created_by_id"
   end
 
-  create_table "library_item_tags", id: false, force: true do |t|
+  create_table "library_item_tags", id: false, force: :cascade do |t|
     t.integer "library_item_id", null: false
     t.integer "tag_id",          null: false
   end
 
-  add_index "library_item_tags", ["library_item_id", "tag_id"], :name => "index_library_item_tags_on_library_item_id_and_tag_id", :unique => true
+  add_index "library_item_tags", ["library_item_id", "tag_id"], name: "index_library_item_tags_on_library_item_id_and_tag_id", unique: true, using: :btree
 
-  create_table "library_items", force: true do |t|
+  create_table "library_items", force: :cascade do |t|
     t.integer  "component_id"
-    t.string   "component_type"
+    t.string   "component_type", limit: 255
     t.integer  "created_by_id",                                           null: false
     t.datetime "created_at",                                              null: false
     t.datetime "updated_at"
     t.datetime "deleted_at"
-    t.spatial  "location",       limit: {:srid=>4326, :type=>"geometry"}
+    t.geometry "location",       limit: {:srid=>4326, :type=>"geometry"}
   end
 
-  add_index "library_items", ["location"], :name => "index_library_items_on_location", :spatial => true
+  add_index "library_items", ["location"], name: "index_library_items_on_location", using: :gist
 
-  create_table "library_notes", force: true do |t|
-    t.integer "library_item_id",     null: false
-    t.string  "title"
-    t.text    "body",                null: false
+  create_table "library_notes", force: :cascade do |t|
+    t.integer "library_item_id",                 null: false
+    t.string  "title",               limit: 255
+    t.text    "body",                            null: false
     t.integer "library_document_id"
   end
 
-  create_table "link_messages", force: true do |t|
-    t.integer  "thread_id",     null: false
-    t.integer  "message_id",    null: false
-    t.integer  "created_by_id", null: false
-    t.text     "url",           null: false
-    t.string   "title"
+  create_table "link_messages", force: :cascade do |t|
+    t.integer  "thread_id",                 null: false
+    t.integer  "message_id",                null: false
+    t.integer  "created_by_id",             null: false
+    t.text     "url",                       null: false
+    t.string   "title",         limit: 255
     t.text     "description"
     t.datetime "created_at"
   end
 
-  create_table "location_categories", force: true do |t|
-    t.string   "name",       null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "location_categories", force: :cascade do |t|
+    t.string   "name",       limit: 255, null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
-  create_table "message_thread_tags", id: false, force: true do |t|
+  create_table "message_thread_tags", id: false, force: :cascade do |t|
     t.integer "thread_id", null: false
     t.integer "tag_id",    null: false
   end
 
-  add_index "message_thread_tags", ["thread_id", "tag_id"], :name => "index_message_thread_tags_on_thread_id_and_tag_id", :unique => true
+  add_index "message_thread_tags", ["thread_id", "tag_id"], name: "index_message_thread_tags_on_thread_id_and_tag_id", unique: true, using: :btree
 
-  create_table "message_threads", force: true do |t|
+  create_table "message_threads", force: :cascade do |t|
     t.integer  "issue_id"
-    t.integer  "created_by_id", null: false
+    t.integer  "created_by_id",             null: false
     t.integer  "group_id"
-    t.string   "title",         null: false
-    t.string   "privacy",       null: false
-    t.string   "zzz_state"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.string   "title",         limit: 255, null: false
+    t.string   "privacy",       limit: 255, null: false
+    t.string   "zzz_state",     limit: 255
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.datetime "deleted_at"
+    t.string   "public_token",  limit: 255
+  end
+
+  add_index "message_threads", ["created_by_id"], name: "index_message_threads_on_created_by_id", using: :btree
+  add_index "message_threads", ["group_id"], name: "index_message_threads_on_group_id", using: :btree
+  add_index "message_threads", ["issue_id"], name: "index_message_threads_on_issue_id", using: :btree
+  add_index "message_threads", ["public_token"], name: "index_message_threads_on_public_token", unique: true, using: :btree
+
+  create_table "messages", force: :cascade do |t|
+    t.integer  "created_by_id",              null: false
+    t.integer  "thread_id",                  null: false
+    t.text     "body",                       null: false
+    t.integer  "component_id"
+    t.string   "component_type", limit: 255
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.datetime "deleted_at"
+    t.datetime "censored_at"
+    t.integer  "in_reply_to_id"
     t.string   "public_token"
   end
 
-  add_index "message_threads", ["created_by_id"], :name => "index_message_threads_on_created_by_id"
-  add_index "message_threads", ["group_id"], :name => "index_message_threads_on_group_id"
-  add_index "message_threads", ["issue_id"], :name => "index_message_threads_on_issue_id"
-  add_index "message_threads", ["public_token"], :name => "index_message_threads_on_public_token", :unique => true
+  add_index "messages", ["created_by_id"], name: "index_messages_on_created_by_id", using: :btree
+  add_index "messages", ["in_reply_to_id"], name: "index_messages_on_in_reply_to_id", using: :btree
+  add_index "messages", ["public_token"], name: "index_messages_on_public_token", unique: true, using: :btree
+  add_index "messages", ["thread_id"], name: "index_messages_on_thread_id", using: :btree
 
-  create_table "messages", force: true do |t|
-    t.integer  "created_by_id",  null: false
-    t.integer  "thread_id",      null: false
-    t.text     "body",           null: false
-    t.integer  "component_id"
-    t.string   "component_type"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.datetime "deleted_at"
-    t.datetime "censored_at"
-  end
-
-  add_index "messages", ["created_by_id"], :name => "index_messages_on_created_by_id"
-  add_index "messages", ["thread_id"], :name => "index_messages_on_thread_id"
-
-  create_table "photo_messages", force: true do |t|
-    t.integer  "thread_id",     null: false
-    t.integer  "message_id",    null: false
-    t.integer  "created_by_id", null: false
-    t.string   "photo_uid",     null: false
-    t.string   "caption"
+  create_table "photo_messages", force: :cascade do |t|
+    t.integer  "thread_id",                 null: false
+    t.integer  "message_id",                null: false
+    t.integer  "created_by_id",             null: false
+    t.string   "photo_uid",     limit: 255, null: false
+    t.string   "caption",       limit: 255
     t.text     "description"
-    t.datetime "created_at",    null: false
+    t.datetime "created_at",                null: false
   end
 
-  create_table "planning_applications", force: true do |t|
+  create_table "planning_applications", force: :cascade do |t|
     t.text     "address"
-    t.string   "postcode"
+    t.string   "postcode",                limit: 255
     t.text     "description"
-    t.string   "openlylocal_council_url"
+    t.string   "openlylocal_council_url", limit: 255
     t.text     "url"
-    t.string   "uid",                                                                          null: false
+    t.string   "uid",                     limit: 255,                                          null: false
     t.integer  "issue_id"
     t.datetime "created_at",                                                                   null: false
     t.datetime "updated_at",                                                                   null: false
-    t.spatial  "location",                limit: {:srid=>4326, :type=>"geometry"}
-    t.string   "authority_name"
+    t.geometry "location",                limit: {:srid=>4326, :type=>"geometry"}
+    t.string   "authority_name",          limit: 255
     t.date     "start_date"
     t.integer  "hide_votes_count",                                                 default: 0
   end
 
-  add_index "planning_applications", ["issue_id"], :name => "index_planning_applications_on_issue_id"
-  add_index "planning_applications", ["uid"], :name => "index_planning_applications_on_uid", :unique => true
+  add_index "planning_applications", ["issue_id"], name: "index_planning_applications_on_issue_id", using: :btree
+  add_index "planning_applications", ["uid"], name: "index_planning_applications_on_uid", unique: true, using: :btree
 
-  create_table "site_comments", force: true do |t|
+  create_table "site_comments", force: :cascade do |t|
     t.integer  "user_id"
-    t.string   "name"
-    t.string   "email"
-    t.text     "body",         null: false
-    t.string   "context_url"
+    t.string   "name",         limit: 255
+    t.string   "email",        limit: 255
+    t.text     "body",                     null: false
+    t.string   "context_url",  limit: 255
     t.text     "context_data"
-    t.datetime "created_at",   null: false
+    t.datetime "created_at",               null: false
     t.datetime "viewed_at"
     t.datetime "deleted_at"
   end
 
-  create_table "street_view_messages", force: true do |t|
+  create_table "street_view_messages", force: :cascade do |t|
     t.integer  "message_id"
     t.integer  "thread_id"
     t.integer  "created_by_id"
@@ -305,77 +309,77 @@ ActiveRecord::Schema.define(version: 20150831090642) do
     t.decimal  "pitch"
     t.datetime "created_at",                                             null: false
     t.datetime "updated_at",                                             null: false
-    t.spatial  "location",      limit: {:srid=>4326, :type=>"geometry"}
+    t.geometry "location",      limit: {:srid=>4326, :type=>"geometry"}
     t.text     "caption"
   end
 
-  add_index "street_view_messages", ["location"], :name => "index_street_view_messages_on_location", :spatial => true
-  add_index "street_view_messages", ["message_id"], :name => "index_street_view_messages_on_message_id"
-  add_index "street_view_messages", ["thread_id"], :name => "index_street_view_messages_on_thread_id"
+  add_index "street_view_messages", ["location"], name: "index_street_view_messages_on_location", using: :gist
+  add_index "street_view_messages", ["message_id"], name: "index_street_view_messages_on_message_id", using: :btree
+  add_index "street_view_messages", ["thread_id"], name: "index_street_view_messages_on_thread_id", using: :btree
 
-  create_table "tags", force: true do |t|
-    t.string "name", null: false
-    t.string "icon"
+  create_table "tags", force: :cascade do |t|
+    t.string "name", limit: 255, null: false
+    t.string "icon", limit: 255
   end
 
-  add_index "tags", ["name"], :name => "index_tags_on_name", :unique => true
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
-  create_table "thread_subscriptions", force: true do |t|
+  create_table "thread_subscriptions", force: :cascade do |t|
     t.integer  "user_id",    null: false
     t.integer  "thread_id",  null: false
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
   end
 
-  add_index "thread_subscriptions", ["thread_id"], :name => "index_thread_subscriptions_on_thread_id"
-  add_index "thread_subscriptions", ["user_id"], :name => "index_thread_subscriptions_on_user_id"
+  add_index "thread_subscriptions", ["thread_id"], name: "index_thread_subscriptions_on_thread_id", using: :btree
+  add_index "thread_subscriptions", ["user_id"], name: "index_thread_subscriptions_on_user_id", using: :btree
 
-  create_table "thread_views", force: true do |t|
+  create_table "thread_views", force: :cascade do |t|
     t.integer  "user_id",   null: false
     t.integer  "thread_id", null: false
     t.datetime "viewed_at", null: false
   end
 
-  add_index "thread_views", ["user_id", "thread_id"], :name => "index_thread_views_on_user_id_and_thread_id", :unique => true
-  add_index "thread_views", ["user_id"], :name => "index_thread_views_on_user_id"
+  add_index "thread_views", ["user_id", "thread_id"], name: "index_thread_views_on_user_id_and_thread_id", unique: true, using: :btree
+  add_index "thread_views", ["user_id"], name: "index_thread_views_on_user_id", using: :btree
 
-  create_table "user_locations", force: true do |t|
+  create_table "user_locations", force: :cascade do |t|
     t.integer  "user_id",                                              null: false
     t.integer  "category_id",                                          null: false
     t.datetime "created_at",                                           null: false
     t.datetime "updated_at",                                           null: false
-    t.spatial  "location",    limit: {:srid=>4326, :type=>"geometry"}
+    t.geometry "location",    limit: {:srid=>4326, :type=>"geometry"}
   end
 
-  add_index "user_locations", ["location"], :name => "index_user_locations_on_location", :spatial => true
-  add_index "user_locations", ["user_id"], :name => "index_user_locations_on_user_id"
+  add_index "user_locations", ["location"], name: "index_user_locations_on_location", using: :gist
+  add_index "user_locations", ["user_id"], name: "index_user_locations_on_user_id", using: :btree
 
-  create_table "user_prefs", force: true do |t|
-    t.integer "user_id",                                       null: false
-    t.string  "involve_my_locations",    default: "subscribe", null: false
-    t.string  "involve_my_groups",       default: "notify",    null: false
-    t.boolean "involve_my_groups_admin", default: false,       null: false
-    t.boolean "enable_email",            default: false,       null: false
-    t.string  "zz_profile_visibility",   default: "public",    null: false
+  create_table "user_prefs", force: :cascade do |t|
+    t.integer "user_id",                                                   null: false
+    t.string  "involve_my_locations",    limit: 255, default: "subscribe", null: false
+    t.string  "involve_my_groups",       limit: 255, default: "notify",    null: false
+    t.boolean "involve_my_groups_admin",             default: false,       null: false
+    t.boolean "enable_email",                        default: false,       null: false
+    t.string  "zz_profile_visibility",   limit: 255, default: "public",    null: false
   end
 
-  add_index "user_prefs", ["enable_email"], :name => "index_user_prefs_on_enable_email"
-  add_index "user_prefs", ["involve_my_groups"], :name => "index_user_prefs_on_involve_my_groups"
-  add_index "user_prefs", ["involve_my_groups_admin"], :name => "index_user_prefs_on_involve_my_groups_admin"
-  add_index "user_prefs", ["involve_my_locations"], :name => "index_user_prefs_on_involve_my_locations"
-  add_index "user_prefs", ["user_id"], :name => "index_user_prefs_on_user_id", :unique => true
+  add_index "user_prefs", ["enable_email"], name: "index_user_prefs_on_enable_email", using: :btree
+  add_index "user_prefs", ["involve_my_groups"], name: "index_user_prefs_on_involve_my_groups", using: :btree
+  add_index "user_prefs", ["involve_my_groups_admin"], name: "index_user_prefs_on_involve_my_groups_admin", using: :btree
+  add_index "user_prefs", ["involve_my_locations"], name: "index_user_prefs_on_involve_my_locations", using: :btree
+  add_index "user_prefs", ["user_id"], name: "index_user_prefs_on_user_id", unique: true, using: :btree
 
-  create_table "user_profiles", force: true do |t|
-    t.integer "user_id",                        null: false
-    t.string  "picture_uid"
-    t.string  "website"
+  create_table "user_profiles", force: :cascade do |t|
+    t.integer "user_id",                                    null: false
+    t.string  "picture_uid", limit: 255
+    t.string  "website",     limit: 255
     t.text    "about"
-    t.string  "visibility",  default: "public", null: false
+    t.string  "visibility",  limit: 255, default: "public", null: false
   end
 
-  add_index "user_profiles", ["user_id"], :name => "index_user_profiles_on_user_id"
+  add_index "user_profiles", ["user_id"], name: "index_user_profiles_on_user_id", using: :btree
 
-  create_table "user_thread_priorities", force: true do |t|
+  create_table "user_thread_priorities", force: :cascade do |t|
     t.integer  "user_id",    null: false
     t.integer  "thread_id",  null: false
     t.integer  "priority",   null: false
@@ -383,50 +387,50 @@ ActiveRecord::Schema.define(version: 20150831090642) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "user_thread_priorities", ["thread_id"], :name => "index_user_thread_priorities_on_thread_id"
-  add_index "user_thread_priorities", ["user_id"], :name => "index_user_thread_priorities_on_user_id"
+  add_index "user_thread_priorities", ["thread_id"], name: "index_user_thread_priorities_on_thread_id", using: :btree
+  add_index "user_thread_priorities", ["user_id"], name: "index_user_thread_priorities_on_user_id", using: :btree
 
-  create_table "users", force: true do |t|
-    t.string   "email",                              default: "", null: false
-    t.string   "full_name",                                       null: false
-    t.string   "display_name"
-    t.string   "role",                                            null: false
+  create_table "users", force: :cascade do |t|
+    t.string   "email",                  limit: 255, default: "", null: false
+    t.string   "full_name",              limit: 255,              null: false
+    t.string   "display_name",           limit: 255
+    t.string   "role",                   limit: 255,              null: false
     t.string   "encrypted_password",     limit: 128, default: ""
-    t.string   "confirmation_token"
+    t.string   "confirmation_token",     limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "reset_password_token"
+    t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.datetime "disabled_at"
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
-    t.string   "invitation_token"
+    t.string   "invitation_token",       limit: 255
     t.datetime "invitation_sent_at"
     t.datetime "invitation_accepted_at"
     t.integer  "remembered_group_id"
     t.integer  "invitation_limit"
     t.integer  "invited_by_id"
-    t.string   "invited_by_type"
+    t.string   "invited_by_type",        limit: 255
     t.datetime "deleted_at"
     t.datetime "invitation_created_at"
   end
 
-  add_index "users", ["email"], :name => "index_users_on_email"
-  add_index "users", ["invitation_token"], :name => "index_users_on_invitation_token"
+  add_index "users", ["email"], name: "index_users_on_email", using: :btree
+  add_index "users", ["invitation_token"], name: "index_users_on_invitation_token", using: :btree
 
-  create_table "votes", force: true do |t|
-    t.boolean  "vote",          default: false
-    t.integer  "voteable_id",                   null: false
-    t.string   "voteable_type",                 null: false
+  create_table "votes", force: :cascade do |t|
+    t.boolean  "vote",                      default: false
+    t.integer  "voteable_id",                               null: false
+    t.string   "voteable_type", limit: 255,                 null: false
     t.integer  "voter_id"
-    t.string   "voter_type"
+    t.string   "voter_type",    limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "votes", ["voteable_id", "voteable_type"], :name => "index_votes_on_voteable_id_and_voteable_type"
-  add_index "votes", ["voter_id", "voter_type", "voteable_id", "voteable_type"], :name => "fk_one_vote_per_user_per_entity", :unique => true
-  add_index "votes", ["voter_id", "voter_type"], :name => "index_votes_on_voter_id_and_voter_type"
+  add_index "votes", ["voteable_id", "voteable_type"], name: "index_votes_on_voteable_id_and_voteable_type", using: :btree
+  add_index "votes", ["voter_id", "voter_type", "voteable_id", "voteable_type"], name: "fk_one_vote_per_user_per_entity", unique: true, using: :btree
+  add_index "votes", ["voter_id", "voter_type"], name: "index_votes_on_voter_id_and_voter_type", using: :btree
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -252,7 +252,7 @@ ActiveRecord::Schema.define(version: 20151012194550) do
     t.datetime "deleted_at"
     t.datetime "censored_at"
     t.integer  "in_reply_to_id"
-    t.string   "public_token"
+    t.string   "public_token",               null: false
   end
 
   add_index "messages", ["created_by_id"], name: "index_messages_on_created_by_id", using: :btree

--- a/lib/mailbox_reader.rb
+++ b/lib/mailbox_reader.rb
@@ -2,23 +2,21 @@ require 'net/imap'
 
 class MailboxReader < MailboxProcessor
   def run
-    begin
-      fetch_message_ids(config[:mailbox]).each do |mid|
-        begin
-          # Fetch message from IMAP server
-          message = fetch_raw_message(mid)
-          # Save to database
-          ar_message = save_message(message)
-          # Send to the mail processor
-          enqueue(ar_message)
-        ensure
-          # Mark message as read in IMAP mailbox
-          mark_as_seen(mid)
-        end
+    fetch_message_ids(config[:mailbox]).each do |mid|
+      begin
+        # Fetch message from IMAP server
+        message = fetch_raw_message(mid)
+        # Save to database
+        ar_message = save_message(message)
+        # Send to the mail processor
+        enqueue(ar_message)
+      ensure
+        # Mark message as read in IMAP mailbox
+        mark_as_seen(mid)
       end
-    ensure
-      disconnect
     end
+  ensure
+    disconnect
   end
 
   def save_message(message)

--- a/spec/features/message_thread/subscriptions_spec.rb
+++ b/spec/features/message_thread/subscriptions_spec.rb
@@ -90,11 +90,12 @@ describe 'Thread subscriptions' do
           fill_in 'Message', with: 'Notification test', match: :first
           click_on 'Post Message'
         end
+        message = Message.find_by(body: 'Notification test')
         open_email(current_user.email, with_subject: /^Re/)
         expect(current_email).to have_subject("Re: [Cyclescape] #{thread.title}")
         expect(current_email).to have_body_text(/Notification test/)
         expect(current_email).to be_delivered_from("#{current_user.name} <notifications@cyclescape.org>")
-        expect(current_email).to have_reply_to("Cyclescape <thread-#{thread.public_token}@cyclescape.org>")
+        expect(current_email).to have_reply_to("Cyclescape <message-#{message.public_token}@cyclescape.org>")
       end
     end
 

--- a/spec/features/message_thread/thread_notifications_spec.rb
+++ b/spec/features/message_thread/thread_notifications_spec.rb
@@ -18,12 +18,13 @@ describe 'thread notifications' do
         fill_in 'Message', with: 'Notification test'
         click_on 'Post Message'
       end
+      message = Message.find_by(body: 'Notification test')
       open_email(current_user.email, with_subject: /^Re/)
       expect(current_email).to have_subject("Re: [Cyclescape] #{thread.title}")
       expect(current_email).to have_body_text(/Notification test/)
       expect(current_email).to have_body_text(current_user.name)
       expect(current_email).to be_delivered_from("#{current_user.name} <notifications@cyclescape.org>")
-      expect(current_email).to have_reply_to("Cyclescape <thread-#{thread.public_token}@cyclescape.org>")
+      expect(current_email).to have_reply_to("Cyclescape <message-#{message.public_token}@cyclescape.org>")
     end
 
     it 'should send an email for a link message' do

--- a/spec/lib/mailbox_reader_spec.rb
+++ b/spec/lib/mailbox_reader_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 MailProcessor = nil
 
 describe MailboxReader do
+  subject { MailboxReader.new(config) }
+
   let(:config) do
     { host: 'mail.example.com', user_name: 'user@example.com', password: 'secret',
       authentication: 'PLAIN', mailbox: 'INBOX', mail_processor: 'MailProcessor' }
@@ -12,7 +14,6 @@ describe MailboxReader do
   let(:message) { File.read(raw_email_path) }
 
   describe '#run' do
-    subject { MailboxReader.new(config) }
     before do
       allow(subject).to receive(:fetch_message_ids).and_return([12345])
       allow(subject).to receive(:fetch_raw_message).with(12345).and_return(message)
@@ -22,20 +23,18 @@ describe MailboxReader do
     it 'ensures mail with errors is marked as read' do
       expect(subject).to receive(:mark_as_seen).with(12345).once
 
-      expect{ subject.run }.to raise_error
+      expect{ subject.run }.to raise_error RuntimeError
     end
 
     it 'ensures connections are disconnected' do
       expect(subject).to receive(:disconnect).once
 
-      expect{ subject.run }.to raise_error
+      expect{ subject.run }.to raise_error SocketError
     end
 
   end
 
   describe 'saving messages' do
-    subject { MailboxReader.new(config) }
-
     describe '#save_message' do
       it 'should create a saved record from the raw message' do
         record = double

--- a/spec/mailers/thread_mailer_spec.rb
+++ b/spec/mailers/thread_mailer_spec.rb
@@ -1,15 +1,21 @@
 require 'spec_helper'
 
 describe ThreadMailer do
-  let(:user) { create(:user) }
-  let(:document) { create(:document_message, created_by: user) }
+  let(:user)          { create(:user) }
+  let(:message_one)   { create(:message, created_by: user) }
+  let(:message_two)   { create(:message, created_by: user, in_reply_to: message_one, thread: thread) }
+  let(:message_three) { create(:message, created_by: user, in_reply_to: message_two, thread: thread) }
+  let(:thread)        { message_one.thread }
+  let!(:document)     { create(:document_message, created_by: user, message: message_three, thread: thread) }
 
   describe 'new document messages' do
     it 'has correct text in email' do
-      subject = described_class.send(:new_document_message, document.message, user)
+      subject = described_class.send(:new_document_message, message_three, user)
       expect(subject.body).to include("http://www.example.com#{document.file.url}")
       expect(subject.body).to include(I18n.t('.thread_mailer.new_document_message.view_the_document'))
       expect(subject.to).to include(user.email)
+      expect(subject.header['References'].value).to eq(
+        "<message-#{message_one.public_token}@cyclescape.org> <message-#{message_two.public_token}@cyclescape.org>")
     end
   end
 end

--- a/spec/mailers/thread_mailer_spec.rb
+++ b/spec/mailers/thread_mailer_spec.rb
@@ -16,7 +16,7 @@ describe ThreadMailer do
       expect(subject.to).to include(user.email)
       expect(subject.header['Message-ID'].value).to eq("<message-#{message_three.public_token}@cyclescape.org>")
       expect(subject.header['References'].value).to eq(
-        "<message-#{message_one.public_token}@cyclescape.org> <message-#{message_two.public_token}@cyclescape.org>")
+        "<thread-#{thread.public_token}@cyclescape.org> <message-#{message_one.public_token}@cyclescape.org> <message-#{message_two.public_token}@cyclescape.org>")
     end
   end
 end

--- a/spec/mailers/thread_mailer_spec.rb
+++ b/spec/mailers/thread_mailer_spec.rb
@@ -14,6 +14,7 @@ describe ThreadMailer do
       expect(subject.body).to include("http://www.example.com#{document.file.url}")
       expect(subject.body).to include(I18n.t('.thread_mailer.new_document_message.view_the_document'))
       expect(subject.to).to include(user.email)
+      expect(subject.header['Message-ID'].value).to eq("<message-#{message_three.public_token}@cyclescape.org>")
       expect(subject.header['References'].value).to eq(
         "<message-#{message_one.public_token}@cyclescape.org> <message-#{message_two.public_token}@cyclescape.org>")
     end

--- a/spec/models/group_membership_request_spec.rb
+++ b/spec/models/group_membership_request_spec.rb
@@ -45,7 +45,7 @@ describe GroupMembershipRequest do
     end
 
     it 'can be confirmed' do
-      expect { subject.confirm! }.to raise_error
+      expect { subject.confirm! }.to raise_error AASM::InvalidTransition
       subject.actioned_by = boss
       expect { subject.confirm! }.not_to raise_error
       expect(subject).to be_valid
@@ -53,7 +53,7 @@ describe GroupMembershipRequest do
     end
 
     it 'can be rejected' do
-      expect { subject.reject! }.to raise_error
+      expect { subject.reject! }.to raise_error AASM::InvalidTransition
       subject.actioned_by = boss
       expect { subject.reject! }.not_to raise_error
       expect(subject).to be_valid
@@ -71,7 +71,7 @@ describe GroupMembershipRequest do
       expect(user.groups.size).to eq(0)
       subject.user = user
       subject.group = group
-      expect { subject.confirm! }.to raise_error
+      expect { subject.confirm! }.to raise_error AASM::InvalidTransition
       expect(user.groups.size).to eq(0)
 
       subject.actioned_by = boss

--- a/spec/models/group_request_spec.rb
+++ b/spec/models/group_request_spec.rb
@@ -60,13 +60,13 @@ describe GroupRequest do
     end
 
     it 'can be confirmed' do
-      expect { subject.confirm! }.to raise_error
+      expect { subject.confirm! }.to raise_error AASM::InvalidTransition
       subject.actioned_by = boss
       expect { subject.confirm! }.not_to raise_error
     end
 
     it 'can be rejected' do
-      expect { subject.reject! }.to raise_error
+      expect { subject.reject! }.to raise_error AASM::InvalidTransition
       subject.actioned_by = boss
       expect { subject.reject! }.not_to raise_error
       expect(subject).to be_valid

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -293,7 +293,7 @@ describe Issue do
 
     it 'should not allow duplicate votes' do
       brian.vote_for(subject)
-      expect { brian.vote_for(subject) }.to raise_error
+      expect { brian.vote_for(subject) }.to raise_error ActiveRecord::RecordInvalid
     end
 
     it 'should allow a change of vote' do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -91,6 +91,12 @@ describe Message do
       expect(subject.in_reply_to).to eq(previous_message)
     end
 
+    it 'errors when set to a message from a different thread' do
+      subject = create(:message)
+      subject.in_reply_to = previous_message
+      expect(subject.errors_on(:in_reply_to_id).size).to eq(1)
+    end
+
     it 'sets in reply to nil with no previous message' do
       subject = create(:message)
       expect(subject.in_reply_to).to be_nil

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -5,6 +5,7 @@ describe Message do
     it { is_expected.to belong_to(:created_by) }
     it { is_expected.to belong_to(:thread) }
     it { is_expected.to belong_to(:component) }
+    it { is_expected.to belong_to(:in_reply_to) }
   end
 
   describe 'validations' do
@@ -22,6 +23,10 @@ describe Message do
 
     it 'should not be censored' do
       expect(subject.censored_at).to be_nil
+    end
+
+    it 'should have a public token' do
+      expect(subject.public_token).to match(/\A[0-9a-f]{20}\Z/)
     end
   end
 
@@ -75,6 +80,20 @@ describe Message do
       message = create(:photo_message).message
       expect(message.searchable_text).to include(message.body)
       expect(message.searchable_text).to include(message.component.searchable_text)
+    end
+  end
+
+  describe 'in reply to' do
+    let(:previous_message) { create(:message) }
+
+    it 'sets in reply to with previous message' do
+      subject = create(:message, thread: previous_message.thread.reload)
+      expect(subject.in_reply_to).to eq(previous_message)
+    end
+
+    it 'sets in reply to nil with no previous message' do
+      subject = create(:message)
+      expect(subject.in_reply_to).to be_nil
     end
   end
 end

--- a/spec/workers/inbound_mail_processor_spec.rb
+++ b/spec/workers/inbound_mail_processor_spec.rb
@@ -12,6 +12,7 @@ describe InboundMailProcessor do
     expect(subject).to respond_to(:perform)
   end
 
+  # This context block can be deleted when we stop accepting old thread reply ids
   context 'thread reply mail' do
     let(:thread) { create(:message_thread) }
     let(:email_recipient) { "thread-#{thread.public_token}@cyclescape.org" }
@@ -50,16 +51,57 @@ describe InboundMailProcessor do
         subject.perform(inbound_mail.id)
       end
     end
+  end
+
+  context 'message reply mail' do
+    let(:message) { create(:message) }
+    let(:thread) { message.thread }
+    let(:email_recipient) { "message-#{message.public_token}@cyclescape.org" }
+    before do
+      subject.perform(inbound_mail.id)
+      thread.reload
+    end
+
+    context 'plain text email' do
+      let(:inbound_mail) { create(:inbound_mail, to: email_recipient) }
+
+      it 'should create a new message on the thread' do
+        expect(thread.messages.size).to eq(2)
+      end
+
+      it 'should have the same text as the email' do
+        # There are weird newline issues here, each \r is duplicated in the model's response
+        expect(thread.messages.last.body).
+          to eq("Hi,\n\nCupcake ipsum dolor sit amet tart gummies. Sweet roll jelly pudding\nmacaroon ice cream. Halvah apple pie sweet. Halvah bear claw pudding.\nBonbon cake powder pastry. Jelly-o candy canes icing jelly macaroon.\nCandy topping chupa chups. Dessert biscuit biscuit gingerbread macaroon\nchupa chups wafer. Oat cake apple pie icing. Candy canes icing dessert.\n\nChocolate cake toffee dessert biscuit tootsie roll powder chocolate\njelly beans marzipan. Pastry tiramisu ice cream jujubes gummi bears.\nCaramels muffin cupcake candy. Caramels pie sweet roll. Jelly beans\ncupcake brownie. Chupa chups tootsie roll bonbon sesame snaps chocolate\ncake bear claw chocolate cake applicake cake. Jelly powder biscuit.\nChupa chups ice cream candy canes icing muffin jelly beans marshmallow.\nIce cream bonbon lemon drops lollipop. Croissant drage applicake\ntopping liquorice.\n\nAndrew\n")
+      end
+
+      it 'should have be created by a new user with the email address' do
+        expect(thread.messages.last.created_by.email).to eq(inbound_mail.message.from.first)
+      end
+
+      it 'should subscribe the user to the thread' do
+        expect(thread.messages.last.created_by.subscribed_to_thread?(thread)).to be_truthy
+      end
+
+      it 'should be sent out' do
+        expect(ThreadNotifier).to receive(:notify_subscribers) do |thread, type, message|
+          expect(thread).to be_a(MessageThread)
+          expect(type).to eq(:new_message)
+          expect(message).to be_a(Message)
+        end
+        subject.perform(inbound_mail.id)
+      end
+    end
 
     context 'multipart text-only email' do
       let(:inbound_mail) { create(:inbound_mail, :multipart_text_only, to: email_recipient) }
 
       it 'should create a new message on the thread' do
-        expect(thread.messages.size).to eq(1)
+        expect(thread.messages.size).to eq(2)
       end
 
       it 'should have the same text as the email text part' do
-        message_body = thread.messages.first.body
+        message_body = thread.messages.last.body
         expect(message_body).to eq("\nOn Tue, 20 Dec 2011, Cyclescape wrote:\n\n> Robin Bird added a message to the thread.\n>\n> I believe the idea is that 20m will be used to work out what to do and\n> how much that would cost. I therefore think that we do need to push for\n> cycle infrastructure along the A14 as a way of allowing them to justify\n> not widening the road quiet so much.\n\nI think the £20m is actually to implement things though, not a feasibility\nstudy. The current consultation seems to be about asking people what the\n£20m should be spent on:\n\nhttp://www.dft.gov.uk/consultations/dft-20111212\n\n\"schemes delivered over the next two years\"\n")
       end
     end
@@ -68,11 +110,11 @@ describe InboundMailProcessor do
       let(:inbound_mail) { create(:inbound_mail, :multipart_iso_8859_1, to: email_recipient) }
 
       it 'should create a new message on the thread' do
-        expect(thread.messages.size).to eq(1)
+        expect(thread.messages.size).to eq(2)
       end
 
       it 'should have the same text as the email text part' do
-        message_body = thread.messages.first.body
+        message_body = thread.messages.last.body
         expect(message_body).to eq("\nOn Tue, 20 Dec 2011, Cyclescape wrote:\n\n> Robin Bird added a message to the thread.\n>\n> I believe the idea is that 20m will be used to work out what to do and\n> how much that would cost. I therefore think that we do need to push for\n> cycle infrastructure along the A14 as a way of allowing them to justify\n> not widening the road quiet so much.\n\nI think the £20m is actually to implement things though, not a feasibility\nstudy. The current consultation seems to be about asking people what the\n£20m should be spent on:\n\nhttp://www.dft.gov.uk/consultations/dft-20111212\n\n\"schemes delivered over the next two years\"\n")
       end
     end
@@ -81,20 +123,20 @@ describe InboundMailProcessor do
       let(:inbound_mail) { create(:inbound_mail, :with_attached_image, to: email_recipient) }
 
       it 'should create two new messages on the thread' do
-        expect(thread.messages.size).to eq(2)
+        expect(thread.messages.size).to eq(3)
       end
 
       it 'should have the first message as the plain text part' do
-        message_body = thread.messages[0].body
+        message_body = thread.messages[1].body
         expect(message_body).to eq("This email has an attached image.\n\nAndy\n\n")
       end
 
       it 'should have the second image as a photo message' do
-        message = thread.messages[1]
-        expect(message.component).to be_a(PhotoMessage)
-        expect(message.component.caption).to eq('abstract-100-100.jpg')
-        expect(message.component.photo.format).to eq('jpeg')
-        expect(message.component.photo.width).to eql(100)
+        new_message = thread.messages[2]
+        expect(new_message.component).to be_a(PhotoMessage)
+        expect(new_message.component.caption).to eq('abstract-100-100.jpg')
+        expect(new_message.component.photo.format).to eq('jpeg')
+        expect(new_message.component.photo.width).to eql(100)
       end
 
       it 'should send multiple notifications' do
@@ -109,16 +151,16 @@ describe InboundMailProcessor do
       let(:inbound_mail) { create(:inbound_mail, :with_attached_file, to: email_recipient) }
 
       it 'should create two new messages on the thread' do
-        expect(thread.messages.size).to eq(2)
+        expect(thread.messages.size).to eq(3)
       end
 
       it 'should have the first message as the plain text part' do
-        message_body = thread.messages[0].body
+        message_body = thread.messages[1].body
         expect(message_body).to eq("This email has an attached file.\n\nAndy\n\n")
       end
 
       it 'should have the second message as an attachment message' do
-        message = thread.messages[1]
+        message = thread.messages[2]
         expect(message.component).to be_a(DocumentMessage)
         expect(message.component.title).to eq('use_cases.pdf')
         expect(message.component.file.format).to eq('pdf')
@@ -130,7 +172,7 @@ describe InboundMailProcessor do
       let(:inbound_mail) { create(:inbound_mail, :encoded_subject, to: email_recipient) }
 
       it 'should work without throwing an encoding error' do
-        expect(thread.messages.size).to eq(1)
+        expect(thread.messages.size).to eq(2)
       end
     end
 
@@ -138,9 +180,10 @@ describe InboundMailProcessor do
       let(:inbound_mail) { create(:inbound_mail, :reply_below_quote, to: email_recipient) }
 
       it "should preserve the blank line between quote and reply" do
-        message_body = thread.messages[0].body
+        message_body = thread.messages.last.body
         expect(message_body).to eql("On Tue, 20 Dec 2011, Cyclescape wrote:\n> Robin Bird added a message to the thread.\n>\n> I believe the idea is that 20m will be used to work out what to do\n\nI believe this is the case too\n\nAndy\n")
       end
     end
   end
+
 end

--- a/spec/workers/new_issue_notifier_spec.rb
+++ b/spec/workers/new_issue_notifier_spec.rb
@@ -32,7 +32,7 @@ describe NewIssueNotifier do
       it 'should queue a notification for each user that has preference set' do
         opts = { 'user_id' => user.id, 'category_id' => location.category_id, 'issue_id' => issue.id }
         expect(Resque).to receive(:enqueue).with(NewIssueNotifier, :notify_new_user_location_issue, opts)
-        subject.process_new_issue(issue)
+        subject.process_new_issue(issue.id)
       end
     end
 


### PR DESCRIPTION
This stores `in_reply_to` on a message which is the previous message (or nil).
In the web UI we store the thread's previous message, with emails we now store the message being replied to (instead of the thread).

In sending email the message id is now the same as the reply to address, basically the message public token.  The email `References` header is now a list of all of the message ids in a thread.

This is seems likely to brake email threading for current threads (as now we are changing from thread to message identification).  To mitigate this I can stick the thread in the `In-Reply-To` header and leave the `References` header as a list of all the messages in the thread.

NOTE: this needs a task to populate all the current message public tokens! 