### PR TITLE
Pull end dates from planit API

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -68,6 +68,7 @@ class PlanningApplication < ActiveRecord::Base
       issue.title = "#{I18n.t("planning_application.issues.new.title_prefix")} : #{title}"
       issue.location = location
       issue.external_url = url
+      issue.deadline = end_date
       issue.description = <<-EOS
         #{description}\n\n
         #{address}\n\n

--- a/db/migrate/20151103200752_add_fields_to_planning_applications.rb
+++ b/db/migrate/20151103200752_add_fields_to_planning_applications.rb
@@ -1,0 +1,8 @@
+class AddFieldsToPlanningApplications < ActiveRecord::Migration
+  def change
+    add_column :planning_applications, :link, :string
+    add_column :planning_applications, :end_date, :datetime
+    add_column :planning_applications, :when_updated, :datetime
+    add_column :planning_applications, :api_get, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151103154232) do
+ActiveRecord::Schema.define(version: 20151103200752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -287,6 +287,10 @@ ActiveRecord::Schema.define(version: 20151103154232) do
     t.string   "authority_name",          limit: 255
     t.date     "start_date"
     t.integer  "hide_votes_count",                                                 default: 0
+    t.string   "link"
+    t.datetime "end_date"
+    t.datetime "when_updated"
+    t.datetime "api_get"
   end
 
   add_index "planning_applications", ["issue_id"], name: "index_planning_applications_on_issue_id", using: :btree

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -26,12 +26,14 @@ describe PlanningApplication do
     end
 
     it 'should populate an issue' do
+      subject.end_date = Date.yesterday
       subject.save!
       issue = subject.populate_issue
       expect(issue.title).to include(subject.title)
       expect(issue.description).to include(subject.description)
       expect(issue.location).to eq(subject.location)
       expect(issue.external_url).to eq(subject.url)
+      expect(issue.deadline).to eq(subject.end_date)
     end
   end
 


### PR DESCRIPTION
Following on from #372

Yes, sadly `other_fields` are not available on the index type action 
/api/applics/json?limit=30
and I can't see a way to turn them on. 

This means every a separate get call for each Planning Application.
Currently we have ~300 000

This might need a re-think....
