### PR TITLE
Mail errors to admin (don't pull directly)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ gem 'sunspot_solr', github: 'nikolai-b/sunspot', branch: 'bb_conjunctions'
 gem 'sunspot_rails', github: 'nikolai-b/sunspot', branch: 'bb_conjunctions'
 gem 'tagsinput-rails'
 
+gem 'exception_notification'
+
 group :development do
   gem 'letter_opener'
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,9 @@ GEM
     equalizer (0.0.11)
     erubis (2.7.0)
     eventmachine (1.0.8)
+    exception_notification (4.1.4)
+      actionmailer (~> 4.0)
+      activesupport (~> 4.0)
     excon (0.45.4)
     execjs (2.6.0)
     factory_girl (4.5.0)
@@ -454,6 +457,7 @@ DEPENDENCIES
   draper
   email_reply_parser
   email_spec
+  exception_notification
   excon
   factory_girl_rails
   foreman

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,3 +62,10 @@ Rails.application.configure do
     config.to_prepare { Devise::RegistrationsController.force_ssl only: [:new, :create, :edit, :update] }
   end
 end
+
+Rails.application.config.middleware.use ExceptionNotification::Rack,
+  :email => {
+    :email_prefix => "[CS-Error] ",
+    :sender_address => %{"notifier" <notifier@cyklistesobe.cz>},
+    :exception_recipients => %w{petr.dlouhy@auto-mat.cz}
+  }


### PR DESCRIPTION
I had a problem, that I didn't get notification about bugs in the application. I solved it with `exception_notification` gem. So this is suggestion, how you can also stay tuned to the site problems.

This PR contains hardcoded my email message, so change that (or use admin email from preferences) before pulling.