### PR TITLE
Make the flash message full width.

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -51,7 +51,8 @@ ul.horizontal, ol.horizontal {
 div.flash-container .flash {
   padding: 6px;
   padding-left: 12px;
-  margin: 10px;
+  margin-top: 10px;
+  margin-bottom: 10px;
   font-weight: bold;
   @include border-radius(5px);
   &.alert {
@@ -62,7 +63,6 @@ div.flash-container .flash {
   &.notice {
     background: $lightgreen;
     color: white;
-    width: 95%;
   }
 }
 
@@ -275,4 +275,3 @@ body.library-notes {
   }
 
 }
-


### PR DESCRIPTION
The flash message was strange - it had a 10px margin both left and right, and then was shrunk by a further 5%, leaving a bigger gap on the right than the left. I thought this was ugly, since the left/right edges didn't line up with anything else.

![screenshot from 2016-03-09 14 34 24](https://cloud.githubusercontent.com/assets/360803/13639132/2ef610aa-e607-11e5-9567-a1d46212a89e.png)

This PR removes both the margin and the explicit 95% width, and I think it looks better.

![screenshot from 2016-03-09 14 36 46](https://cloud.githubusercontent.com/assets/360803/13639153/4d806908-e607-11e5-94ce-8b0b6e9f878f.png)
