### PR TITLE
Increase length of library note titles.

### DIFF
--- a/app/models/library/note.rb
+++ b/app/models/library/note.rb
@@ -30,7 +30,7 @@ class Library::Note < Library::Component
   def title
     field = read_attribute(:title)
     if field.blank?
-      body.truncate(30)
+      body.truncate(120)
     else
       field
     end


### PR DESCRIPTION
Most of the library notes on the summary page are incomprehensible because they are only 30 characters long.

![screenshot from 2016-03-09 15 56 05](https://cloud.githubusercontent.com/assets/360803/13641289/c7bba0fe-e60f-11e5-84a9-00acff08d346.png)

This PR lengthens them to 120, and I think they look much better.

![screenshot from 2016-03-09 15 56 12](https://cloud.githubusercontent.com/assets/360803/13641310/dc644164-e60f-11e5-9c44-e3c5bd3c361b.png)

A balance needs to be struck - 255 (with simple_format) looks good
on the library#show page, but is too long on the note#show when
actually used as an h1-sized title.