### PR TITLE
Align anonymous users correctly in messages.

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -135,7 +135,7 @@ article.message {
   min-height: 60px;
   .details {
     padding: 4px;
-    .author a {
+    .author .name {
       margin-left: 4px;
     }
     .thumbnail {
@@ -275,4 +275,3 @@ body.library-notes {
   }
 
 }
-

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -6,9 +6,12 @@
         %span.thumbnail
           - if message.created_by.profile.picture
             = image_tag message.created_by.profile.picture_thumbnail.url, alt: ""
-        = link_to_profile message.created_by
+        %span.name
+          = link_to_profile message.created_by
       - else
-        = message.created_by.display_name_or_anon
+        %span.thumbnail
+        %span.name
+          = message.created_by.display_name_or_anon
       = t '.committee' if message.committee_created?
       = link_to thread_path(anchor: dom_id(message)), class: "permalink" do
         - time_tag_with_title(message.created_at) do


### PR DESCRIPTION
The empty thumbnail is required for most of the spacing. A small
change is made to add the 4px margin to a span, rather than the link,
since anonymous users won't be linked.

Before:
![screenshot from 2016-03-09 16 25 56](https://cloud.githubusercontent.com/assets/360803/13642350/00051e5a-e614-11e5-9b9d-7787e44a6d69.png)

----

After:
![screenshot from 2016-03-09 16 26 20](https://cloud.githubusercontent.com/assets/360803/13642351/000b9c80-e614-11e5-9842-f5321f188063.png)

