### PR TITLE
528 ignore messages in moderation

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,6 @@
 class GroupsController < ApplicationController
   def index
-    groups = Group.page params[:page]
+    groups = Group.ordered.page params[:page]
 
     @groups = GroupDecorator.decorate_collection groups
     @start_location = index_start_location

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -34,6 +34,8 @@ class Group < ActiveRecord::Base
   after_create :create_default_prefs, unless: :prefs
   before_destroy :unlink_threads
 
+  scope :ordered, -> { order(threads_count: :desc) }
+
   def committee_members
     members.includes(:memberships).where(group_memberships: {role: 'committee'}).
       order("LOWER(COALESCE(NULLIF(users.display_name, ''), NULLIF(users.full_name, '')))").references(:group_memberships)

--- a/app/models/message_thread.rb
+++ b/app/models/message_thread.rb
@@ -225,7 +225,7 @@ class MessageThread < ActiveRecord::Base
   end
 
   def latest_activity_at
-    messages.empty? ? updated_at : messages.maximum('messages.updated_at')
+    messages.approved.empty? ? updated_at : messages.maximum('messages.updated_at')
   end
 
   def latest_activity_at_to_i
@@ -233,7 +233,7 @@ class MessageThread < ActiveRecord::Base
   end
 
   def latest_activity_by
-    messages.empty? ? created_by : messages.last.created_by
+    messages.approved.empty? ? created_by : messages.last.created_by
   end
 
   def default_centre

--- a/app/models/message_thread.rb
+++ b/app/models/message_thread.rb
@@ -46,7 +46,7 @@ class MessageThread < ActiveRecord::Base
   NON_COMMITTEE_ALLOWED_PRIVACY = ALL_ALLOWED_PRIVACY - %w(private committee)
 
   belongs_to :created_by, class_name: 'User'
-  belongs_to :group, inverse_of: :threads
+  belongs_to :group, inverse_of: :threads, counter_cache: true
   belongs_to :issue
   belongs_to :user, inverse_of: :private_threads
   has_many :messages, -> { order('created_at ASC') }, foreign_key: 'thread_id', autosave: true, inverse_of: :thread

--- a/db/migrate/20160309205413_add_message_threads_count_to_groups.rb
+++ b/db/migrate/20160309205413_add_message_threads_count_to_groups.rb
@@ -1,0 +1,6 @@
+class AddMessageThreadsCountToGroups < ActiveRecord::Migration
+  def change
+    add_column :groups, :message_threads_count, :integer
+    Group.ids.each { |group_id| Group.reset_counters(group_id, :threads) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160308000500) do
+ActiveRecord::Schema.define(version: 20160309205413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,7 @@ ActiveRecord::Schema.define(version: 20160308000500) do
     t.datetime "updated_at",                                            null: false
     t.datetime "disabled_at"
     t.string   "default_thread_privacy", limit: 255, default: "public", null: false
+    t.integer  "message_threads_count"
   end
 
   add_index "groups", ["short_name"], name: "index_groups_on_short_name", using: :btree

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -21,6 +21,13 @@ describe Group do
     end
   end
 
+  describe 'scopes' do
+    it 'has ordered scope' do
+      create :group
+      expect(described_class.ordered.count).to eq 1
+    end
+  end
+
   describe 'newly created' do
     subject { create(:group) }
 

--- a/spec/models/message_thread_spec.rb
+++ b/spec/models/message_thread_spec.rb
@@ -146,6 +146,16 @@ describe MessageThread do
     end
   end
 
+  it '#latest_activity_at' do
+    thread = create(:message_thread, :with_messages)
+    newest_message = thread.messages.last
+    tomorrow = 1.day.from_now
+    newest_message.update(updated_at: tomorrow)
+    expect(thread.latest_activity_at).to be_within(1).of tomorrow
+    newest_message.update_column(:status, 'mod_queued')
+    expect(thread.latest_activity_at).to_not eq tomorrow
+  end
+
   context 'public token' do
     it 'should be set after being created' do
       thread = create(:message_thread)


### PR DESCRIPTION
I think #528 is caused when threads aren't approved.  I'm adding `approved` scope.