### PR TITLE
Switch language based on the Accept-Language header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'paranoia', '~> 2.0'
 gem 'mustache'
 gem 'icalendar'
 gem 'attribute_normalizer'
+gem 'http_accept_language'
 
 gem 'grape', github: 'ruby-grape/grape'
 gem 'grape-swagger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
+    http_accept_language (2.0.5)
     i18n (0.7.0)
     icalendar (2.3.0)
     ice_nine (0.11.1)
@@ -480,6 +481,7 @@ DEPENDENCIES
   grape-kaminari
   grape-swagger
   haml-rails
+  http_accept_language
   icalendar
   jquery-rails (~> 3.0.0)
   jquery-ui-rails (~> 5.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   before_filter :ensure_proper_protocol
   before_filter :no_disabled_users
+  before_filter :set_locale
   before_filter :set_auth_user
   before_filter :load_group_from_subdomain
   before_filter :set_page_title
@@ -80,6 +81,10 @@ class ApplicationController < ActionController::Base
       sign_out current_user
       redirect_to root_path, alert: t('application.account_disabled')
     end
+  end
+
+  def set_locale
+    I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales) || I18n.default_locale
   end
 
   def set_auth_user

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module Cyclescape
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
+    config.i18n.available_locales = %w(en-GB de-DE cs-CZ)
     config.i18n.enforce_available_locales = true
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,11 @@ Rails.application.configure do
     g.stylesheets false
   end
 
+  # If you want to avoid falling back to en-GB translations (i.e. you want
+  # all missing translations in your language to throw errors) then set this
+  # to `false`
+  config.i18n.fallbacks = true
+
   config.action_view.raise_on_missing_translations = true
   config.assets.raise_runtime_errors = true
   # Disable analytics


### PR DESCRIPTION
Implements the first part of #277 . This uses a plugin to do all the heavy lifting of parsing the Accept-Language header and switching to the most appropriate locale that we have translations for.