### PR TITLE
386 admin planning filter

### DIFF
--- a/app/controllers/admin/planning_filters_controller.rb
+++ b/app/controllers/admin/planning_filters_controller.rb
@@ -1,0 +1,46 @@
+class Admin::PlanningFiltersController < ApplicationController
+  def index
+    @planning_filters = PlanningFilter.all
+  end
+
+  def show
+    filter
+  end
+
+  def edit
+    filter
+  end
+
+  def new
+    @filter = PlanningFilter.new
+  end
+
+  def update
+    if filter.update permitted_params
+      set_flash_message :success
+      redirect_to action: :index
+    else
+      render :edit
+    end
+  end
+
+  def create
+    @filter = PlanningFilter.new(permitted_params)
+
+    if filter.save
+      set_flash_message :success
+      redirect_to action: :index
+    else
+      render :new
+    end
+  end
+  private
+
+  def permitted_params
+    params.require(:planning_filter).permit :authority, :rule
+  end
+
+  def filter
+    @filter ||= PlanningFilter.find(params[:id])
+  end
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -84,20 +84,16 @@ class PlanningApplication < ActiveRecord::Base
     end
   end
 
-  protected
+  def calculate_relavant(loaded_planning_filters = nil)
+    planning_filters = loaded_planning_filters || PlanningFilter.all
+    planning_filters.none? { |filter| filter.matches?(self) }
+  end
+
+  private
 
   def set_relevant
-    self.relevant = relevant?
+    self.relevant = calculate_relavant
     true
   end
 
-  def relevant?
-    return true unless authority_name == 'Cambridge'
-    case uid
-    when /\/(TTCA|TTPO|COND.*|CON\d*|CLUED|ADV)$/
-      false
-    else
-      true
-    end
-  end
 end

--- a/app/models/planning_filter.rb
+++ b/app/models/planning_filter.rb
@@ -1,0 +1,84 @@
+class PlanningFilter < ActiveRecord::Base
+  LOCAL_AUTHORITIES = [
+    'Aberdeen', 'Aberdeenshire', 'Adur', 'Adur and Worthing', 'Alderney', 'Allerdale', 'Amber Valley', 'Anglesey', 'Angus', 'Antrim',
+    'Antrim and Newtownabbey', 'Ards', 'Ards and North Down', 'Argyll', 'Armagh', 'Armagh Banbridge Craigavon', 'Arun', 'Ashfield',
+    'Ashford', 'Aylesbury Vale', 'Babergh', 'Ballymena', 'Ballymoney', 'Banbridge', 'Barking and Dagenham', 'Barnet', 'Barnsley', 'Barrow',
+    'Basildon', 'Basingstoke', 'Bassetlaw', 'Bath', 'Bedford', 'Belfast', 'Bexley', 'Birmingham', 'Blaby', 'Blackburn', 'Blackpool',
+    'Blaenau Gwent', 'Bolsover', 'Bolton', 'Boston', 'Bournemouth', 'Bracknell', 'Bradford', 'Braintree', 'Breckland', 'Brecon Beacons',
+    'Brent', 'Brentwood', 'Bridgend', 'Brighton', 'Bristol', 'British Islands', 'Broadland', 'Broads', 'Bromley', 'Bromsgrove',
+    'Broxbourne', 'Broxtowe', 'Buckinghamshire', 'Burnley', 'Bury', 'Caerphilly', 'Cairngorms', 'Calderdale', 'Cambridge',
+    'Cambridgeshire', 'Camden', 'Cannock Chase', 'Canterbury', 'Cardiff', 'Carlisle', 'Carmarthenshire', 'Carrickfergus', 'Castle Point',
+    'Castlereagh', 'Causeway and Glens', 'Central Bedfordshire', 'Ceredigion', 'Channel Islands', 'Charnwood', 'Chelmsford', 'Cheltenham',
+    'Cherwell', 'Cheshire East', 'Chester', 'Chesterfield', 'Chichester', 'Chiltern', 'Chorley', 'Christchurch', 'City', 'Clackmannan',
+    'Colchester', 'Coleraine', 'Conwy', 'Cookstown', 'Copeland', 'Corby', 'Cornwall', 'Cotswold', 'Coventry', 'Craigavon', 'Craven',
+    'Crawley', 'Croydon', 'Cumbria', 'Dacorum', 'Darlington', 'Dartford', 'Dartmoor', 'Daventry', 'Denbighshire', 'Derby', 'Derbyshire',
+    'Derbyshire Dales', 'Derry', 'Derry and Strabane', 'Devon', 'Doncaster', 'Dorset', 'Dover', 'Down', 'Dudley', 'Dumfries', 'Dundee',
+    'Dungannon', 'Durham', 'Durham (Barnard Castle)', 'Durham (Chester-le-Street)', 'Durham (City)', 'Durham (Consett)', 'Durham (County)',
+    'Durham (Crook)', 'Durham (Easington)', 'Durham (Sedgefield)', 'Ealing', 'East Ayr', 'East Cambridgeshire', 'East Devon', 'East Dorset',
+    'East Dunbarton', 'East England', 'East Hampshire', 'East Hertfordshire', 'East Lindsey', 'East Lothian', 'East Midlands',
+    'East Northamptonshire', 'East Renfrew', 'East Riding', 'East Staffordshire', 'East Sussex', 'East Wiltshire', 'Eastbourne',
+    'Eastleigh', 'Eden', 'Edinburgh', 'Elmbridge', 'Enfield', 'England', 'England and Wales', 'Epping Forest', 'Epsom and Ewell',
+    'Erewash', 'Essex', 'Exeter', 'Exmoor', 'Falkirk', 'Fareham', 'Fenland', 'Fermanagh', 'Fermanagh and Omagh', 'Fife', 'Flintshire',
+    'Forest Heath', 'Forest of Dean', 'Fylde', 'Gateshead', 'Gedling', 'Glamorgan', 'Glasgow', 'Gloucester', 'Gloucestershire', 'Gosport',
+    'Gravesham', 'Great Britain', 'Great Yarmouth', 'Greater Manchester', 'Greenwich', 'Guernsey', 'Guernsey Bailiwick', 'Guildford',
+    'Gwynedd', 'Hackney', 'Halton', 'Hambleton', 'Hammersmith and Fulham', 'Hampshire', 'Harborough', 'Haringey', 'Harlow', 'Harrogate',
+    'Harrow', 'Hart', 'Hartlepool', 'Hastings', 'Havant', 'Havering', 'Herefordshire', 'Hertfordshire', 'Hertsmere', 'High Peak',
+    'Highland', 'Hillingdon', 'Hinckley and Bosworth', 'Horsham', 'Hounslow', 'Hull', 'Huntingdonshire', 'Hyndburn', 'Inverclyde',
+    'Ipswich', 'Isle of Man', 'Isle of Wight', 'Islington', 'Jersey', 'Kensington', 'Kent', 'Kettering', 'Kings Lynn', 'Kingston',
+    'Kirklees', 'Knowsley', 'Lake District', 'Lambeth', 'Lancashire', 'Lancaster', 'Larne', 'Leeds', 'Leicester', 'Leicestershire',
+    'Lewes', 'Lewisham', 'Lichfield', 'Limavady', 'Lincoln', 'Lincolnshire', 'Lisburn', 'Lisburn and Castlereagh', 'Liverpool', 'Loch Lomond',
+    'London', 'London Legacy', 'Luton', 'Magherafelt', 'Maidstone', 'Maldon', 'Malvern Hills', 'Manchester', 'Mansfield',
+    'Medway', 'Melton', 'Mendip', 'Merseyside', 'Merthyr Tydfil', 'Merton', 'Mid Devon', 'Mid East Antrim', 'Mid Kent', 'Mid Suffolk',
+    'Mid Sussex', 'Mid Ulster', 'Middlesbrough', 'Midlothian', 'Milton Keynes', 'Mole Valley', 'Monmouthshire', 'Moray', 'Moyle', 'Neath',
+    'New Forest (District)', 'New Forest (Park)', 'Newark and Sherwood', 'Newcastle under Lyme', 'Newcastle upon Tyne', 'Newham', 'Newport',
+    'Newry Mourne Down', 'Newry and Mourne', 'Newtownabbey', 'Norfolk', 'North Ayr', 'North Devon', 'North Dorset', 'North Down',
+    'North East', 'North East Derbyshire', 'North East Lincs', 'North Hertfordshire', 'North Kesteven', 'North Lanark', 'North Lincs',
+    'North Norfolk', 'North Somerset', 'North Tyneside', 'North Warwickshire', 'North West', 'North West Leicestershire', 'North Wiltshire',
+    'North York Moors', 'North Yorkshire', 'Northampton', 'Northamptonshire', 'Northern Ireland', 'Northumberland (County)',
+    'Northumberland (Park)', 'Norwich', 'Nottingham', 'Nottinghamshire', 'Nuneaton', 'Oadby and Wigston', 'Oldham', 'Omagh', 'Orkney',
+    'Oxford', 'Oxfordshire', 'Peak District', 'Pembroke Coast', 'Pembrokeshire', 'Pendle', 'Perth', 'Peterborough',
+    'Planning Inspectorate', 'Plymouth', 'Poole', 'Portsmouth', 'Powys', 'Preston', 'Purbeck', 'Reading', 'Redbridge', 'Redcar and Cleveland',
+    'Redditch', 'Reigate', 'Renfrew', 'Rhondda', 'Ribble Valley', 'Richmond', 'Richmondshire', 'Rochdale', 'Rochford', 'Rossendale',
+    'Rother', 'Rotherham', 'Rugby', 'Runnymede', 'Rushcliffe', 'Rushmoor', 'Rutland', 'Ryedale', 'Salford', 'Sandwell', 'Sark',
+    'Scarborough', 'Scilly Isles', 'Scotland', 'Scottish Borders', 'Sedgemoor', 'Sefton', 'Selby', 'Sevenoaks', 'Sheffield', 'Shepway',
+    'Shetlands', 'Shropshire', 'Slough', 'Snowdonia', 'Solihull', 'Somerset', 'South Ayr', 'South Bucks', 'South Cambridgeshire',
+    'South Derbyshire', 'South Downs', 'South East', 'South Gloucestershire', 'South Hams', 'South Holland', 'South Kesteven', 'South Lakeland',
+    'South Lanark', 'South Norfolk', 'South Northamptonshire', 'South Oxfordshire', 'South Ribble', 'South Somerset',
+    'South Staffordshire', 'South Tyneside', 'South West', 'South Wiltshire', 'South Yorkshire', 'Southampton', 'Southend', 'Southwark',
+    'Spelthorne', 'St Albans', 'St Edmundsbury', 'St Helens', 'Stafford', 'Staffordshire', 'Staffordshire Moorlands', 'Stevenage',
+    'Stirling', 'Stockport', 'Stockton-on-Tees', 'Stoke on Trent', 'Strabane', 'Stratford on Avon', 'Stroud', 'Suffolk', 'Suffolk Coastal',
+    'Sunderland', 'Surrey', 'Surrey Heath', 'Sutton', 'Swale', 'Swansea', 'Swindon', 'Tameside', 'Tamworth', 'Tandridge', 'Taunton Deane',
+    'Teignbridge', 'Telford', 'Tendring', 'Test Valley', 'Tewkesbury', 'Thanet', 'Three Rivers', 'Thurrock', 'Tonbridge', 'Torbay',
+    'Torfaen', 'Torridge', 'Tower Hamlets', 'Trafford', 'Tunbridge Wells', 'Tyne and Wear', 'United Kingdom', 'Uttlesford',
+    'Vale of White Horse', 'Wakefield', 'Wales', 'Walsall', 'Waltham Forest', 'Wandsworth', 'Warrington', 'Warwick', 'Warwickshire', 'Watford', 'Waveney',
+    'Waverley', 'Wealden', 'Wellingborough', 'Welwyn Hatfield', 'West Berkshire', 'West Devon', 'West Dorset', 'West Dunbarton',
+    'West Lancashire', 'West Lindsey', 'West Lothian', 'West Midlands', 'West Midlands County', 'West Oxfordshire', 'West Somerset',
+    'West Suffolk', 'West Sussex', 'West Wiltshire', 'West Yorkshire', 'Western Isles', 'Westminster', 'Weymouth', 'Wigan', 'Wiltshire',
+    'Winchester', 'Windsor', 'Wirral', 'Woking', 'Wokingham', 'Wolverhampton', 'Worcester', 'Worcestershire', 'Worthing', 'Wrexham',
+    'Wychavon', 'Wycombe', 'Wyre', 'Wyre Forest', 'York', 'Yorkshire Dales', 'Yorkshire and Humber',
+  ].freeze
+
+  validates :authority, inclusion: { in: LOCAL_AUTHORITIES }
+  validate :ensure_rule_is_valid_regex
+
+  after_save :update_relevancies
+
+  def matches?(planning_application)
+    return false unless planning_application.authority_name == authority
+    Regexp.new(rule).match(planning_application.uid)
+  end
+
+  private
+
+  def update_relevancies
+    Resque.enqueue(SearchUpdater, :update_relevant_planning_applications)
+  end
+
+  def ensure_rule_is_valid_regex
+    return unless rule
+    Regexp.new rule
+  rescue => e
+    errors.add(:rule, e.message)
+  end
+
+end

--- a/app/views/admin/home/index.html.haml
+++ b/app/views/admin/home/index.html.haml
@@ -7,3 +7,5 @@
   %li= link_to t(".manage_comments"), site_comments_path
   %li= link_to t(".manage_message_moderations"), admin_message_moderations_path
   %li= link_to 'Stats', admin_stats_path
+  %li= link_to 'Resque', resque_server_path
+  %li= link_to 'Planning Filters', admin_planning_filters_path

--- a/app/views/admin/planning_filters/_filter.html.haml
+++ b/app/views/admin/planning_filters/_filter.html.haml
@@ -1,0 +1,5 @@
+%tr
+  %td= link_to filter.id, admin_planning_filter_path(filter)
+  %td= filter.authority
+  %td= filter.rule
+  %td= link_to 'edit', edit_admin_planning_filter_path(filter)

--- a/app/views/admin/planning_filters/_form.html.haml
+++ b/app/views/admin/planning_filters/_form.html.haml
@@ -1,5 +1,5 @@
 = semantic_form_for @filter,  url: [:admin, @filter] do |f|
   = f.inputs do
-    = f.input :authority, as: :select, collection: PlanningFilter::LOCAL_AUTHORITIES
+    = f.input :authority, as: :select, collection: [PlanningFilter::STAR] + PlanningFilter::LOCAL_AUTHORITIES
     = f.input :rule
   = f.actions

--- a/app/views/admin/planning_filters/_form.html.haml
+++ b/app/views/admin/planning_filters/_form.html.haml
@@ -1,0 +1,5 @@
+= semantic_form_for @filter,  url: [:admin, @filter] do |f|
+  = f.inputs do
+    = f.input :authority, as: :select, collection: PlanningFilter::LOCAL_AUTHORITIES
+    = f.input :rule
+  = f.actions

--- a/app/views/admin/planning_filters/edit.html.haml
+++ b/app/views/admin/planning_filters/edit.html.haml
@@ -1,0 +1,4 @@
+%header
+  %h1 Planning Filter
+%section
+  = render "form"

--- a/app/views/admin/planning_filters/index.html.haml
+++ b/app/views/admin/planning_filters/index.html.haml
@@ -1,0 +1,11 @@
+%h1 Planning Filters
+%section
+  .tasks
+    %p= link_to "New Planning Filter", new_admin_planning_filter_path
+  %table
+    %thead
+      %th Id
+      %th Authority
+      %th Rule
+    %tbody
+      = render collection: @planning_filters, partial: "filter"

--- a/app/views/admin/planning_filters/new.html.haml
+++ b/app/views/admin/planning_filters/new.html.haml
@@ -1,0 +1,4 @@
+%header
+  %h1 Planning Filter
+%section
+  = render "form"

--- a/app/views/admin/planning_filters/show.html.haml
+++ b/app/views/admin/planning_filters/show.html.haml
@@ -1,0 +1,4 @@
+%header
+  %h1 Planning Filter
+%section
+  = render partial: "filter", locals: { filter: @filter}

--- a/app/workers/search_updater.rb
+++ b/app/workers/search_updater.rb
@@ -8,6 +8,20 @@ class SearchUpdater
     send(method, *args)
   end
 
+  # cheekily added, we have too many queues, low, medium and high priority is enough
+  def self.update_relevant_planning_applications
+    planning_filters = PlanningFilter.all
+
+    PlanningApplication.transaction do
+      PlanningApplication.find_each do |pa|
+        new_relavant = pa.calculate_relavant(planning_filters)
+        if pa.relevant != new_relavant
+          pa.update(relevant: new_relavant)
+        end
+      end
+    end
+  end
+
   def self.update_type(item, type)
     Resque.enqueue(SearchUpdater, type, item.id)
   end

--- a/config/authorization_rules.rb
+++ b/config/authorization_rules.rb
@@ -14,6 +14,7 @@ authorization do
     has_permission_on :admin_home, to: :view
     has_permission_on :admin_message_moderations, to: :view
     has_permission_on :admin_stats, to: :view
+    has_permission_on :admin_planning_filters, to: :manage
     has_permission_on :issues, to: [:edit, :update, :destroy]
     has_permission_on :library_documents, :library_notes, to: [:edit, :update]
     has_permission_on :message_threads, :group_message_threads, :issue_message_threads, to: :manage

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
     resources :groups
     resources :stats, only: :index
     resources :message_moderations, only: :index
+    resources :planning_filters
     resources :users do
       put :approve, on: :member
       scope module: 'user' do

--- a/db/migrate/20160504190635_create_planning_filters.rb
+++ b/db/migrate/20160504190635_create_planning_filters.rb
@@ -1,0 +1,10 @@
+class CreatePlanningFilters < ActiveRecord::Migration
+  def change
+    create_table :planning_filters do |t|
+      t.string :authority
+      t.string :rule
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -427,7 +427,7 @@ ActiveRecord::Schema.define(version: 20160604124124) do
 
   create_table "user_locations", force: :cascade do |t|
     t.integer  "user_id",                                              null: false
-    t.integer  "category_id",                                          null: false
+    t.integer  "category_id"
     t.datetime "created_at",                                           null: false
     t.datetime "updated_at",                                           null: false
     t.geometry "location",    limit: {:srid=>4326, :type=>"geometry"}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -360,6 +360,13 @@ ActiveRecord::Schema.define(version: 20160604124124) do
   add_index "planning_applications", ["uid"], name: "index_planning_applications_on_uid", using: :btree
   add_index "planning_applications", ["zzz_issue_id"], name: "index_planning_applications_on_zzz_issue_id", using: :btree
 
+  create_table "planning_filters", force: :cascade do |t|
+    t.string   "authority"
+    t.string   "rule"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "site_comments", force: :cascade do |t|
     t.integer  "user_id"
     t.string   "name",         limit: 255
@@ -420,7 +427,7 @@ ActiveRecord::Schema.define(version: 20160604124124) do
 
   create_table "user_locations", force: :cascade do |t|
     t.integer  "user_id",                                              null: false
-    t.integer  "category_id"
+    t.integer  "category_id",                                          null: false
     t.datetime "created_at",                                           null: false
     t.datetime "updated_at",                                           null: false
     t.geometry "location",    limit: {:srid=>4326, :type=>"geometry"}

--- a/lib/planning_application_worker.rb
+++ b/lib/planning_application_worker.rb
@@ -1,71 +1,13 @@
 class PlanningApplicationWorker
   # Update to use
   # http://planit.org.uk/find/areas/json
-  LOCAL_AUTHORITIES = [
-    'Aberdeen', 'Aberdeenshire', 'Adur', 'Adur and Worthing', 'Alderney', 'Allerdale', 'Amber Valley', 'Anglesey', 'Angus', 'Antrim',
-    'Antrim and Newtownabbey', 'Ards', 'Ards and North Down', 'Argyll', 'Armagh', 'Armagh Banbridge Craigavon', 'Arun', 'Ashfield',
-    'Ashford', 'Aylesbury Vale', 'Babergh', 'Ballymena', 'Ballymoney', 'Banbridge', 'Barking and Dagenham', 'Barnet', 'Barnsley', 'Barrow',
-    'Basildon', 'Basingstoke', 'Bassetlaw', 'Bath', 'Bedford', 'Belfast', 'Bexley', 'Birmingham', 'Blaby', 'Blackburn', 'Blackpool',
-    'Blaenau Gwent', 'Bolsover', 'Bolton', 'Boston', 'Bournemouth', 'Bracknell', 'Bradford', 'Braintree', 'Breckland', 'Brecon Beacons',
-    'Brent', 'Brentwood', 'Bridgend', 'Brighton', 'Bristol', 'British Islands', 'Broadland', 'Broads', 'Bromley', 'Bromsgrove',
-    'Broxbourne', 'Broxtowe', 'Buckinghamshire', 'Burnley', 'Bury', 'Caerphilly', 'Cairngorms', 'Calderdale', 'Cambridge',
-    'Cambridgeshire', 'Camden', 'Cannock Chase', 'Canterbury', 'Cardiff', 'Carlisle', 'Carmarthenshire', 'Carrickfergus', 'Castle Point',
-    'Castlereagh', 'Causeway and Glens', 'Central Bedfordshire', 'Ceredigion', 'Channel Islands', 'Charnwood', 'Chelmsford', 'Cheltenham',
-    'Cherwell', 'Cheshire East', 'Chester', 'Chesterfield', 'Chichester', 'Chiltern', 'Chorley', 'Christchurch', 'City', 'Clackmannan',
-    'Colchester', 'Coleraine', 'Conwy', 'Cookstown', 'Copeland', 'Corby', 'Cornwall', 'Cotswold', 'Coventry', 'Craigavon', 'Craven',
-    'Crawley', 'Croydon', 'Cumbria', 'Dacorum', 'Darlington', 'Dartford', 'Dartmoor', 'Daventry', 'Denbighshire', 'Derby', 'Derbyshire',
-    'Derbyshire Dales', 'Derry', 'Derry and Strabane', 'Devon', 'Doncaster', 'Dorset', 'Dover', 'Down', 'Dudley', 'Dumfries', 'Dundee',
-    'Dungannon', 'Durham', 'Durham (Barnard Castle)', 'Durham (Chester-le-Street)', 'Durham (City)', 'Durham (Consett)', 'Durham (County)',
-    'Durham (Crook)', 'Durham (Easington)', 'Durham (Sedgefield)', 'Ealing', 'East Ayr', 'East Cambridgeshire', 'East Devon', 'East Dorset',
-    'East Dunbarton', 'East England', 'East Hampshire', 'East Hertfordshire', 'East Lindsey', 'East Lothian', 'East Midlands',
-    'East Northamptonshire', 'East Renfrew', 'East Riding', 'East Staffordshire', 'East Sussex', 'East Wiltshire', 'Eastbourne',
-    'Eastleigh', 'Eden', 'Edinburgh', 'Elmbridge', 'Enfield', 'England', 'England and Wales', 'Epping Forest', 'Epsom and Ewell',
-    'Erewash', 'Essex', 'Exeter', 'Exmoor', 'Falkirk', 'Fareham', 'Fenland', 'Fermanagh', 'Fermanagh and Omagh', 'Fife', 'Flintshire',
-    'Forest Heath', 'Forest of Dean', 'Fylde', 'Gateshead', 'Gedling', 'Glamorgan', 'Glasgow', 'Gloucester', 'Gloucestershire', 'Gosport',
-    'Gravesham', 'Great Britain', 'Great Yarmouth', 'Greater Manchester', 'Greenwich', 'Guernsey', 'Guernsey Bailiwick', 'Guildford',
-    'Gwynedd', 'Hackney', 'Halton', 'Hambleton', 'Hammersmith and Fulham', 'Hampshire', 'Harborough', 'Haringey', 'Harlow', 'Harrogate',
-    'Harrow', 'Hart', 'Hartlepool', 'Hastings', 'Havant', 'Havering', 'Herefordshire', 'Hertfordshire', 'Hertsmere', 'High Peak',
-    'Highland', 'Hillingdon', 'Hinckley and Bosworth', 'Horsham', 'Hounslow', 'Hull', 'Huntingdonshire', 'Hyndburn', 'Inverclyde',
-    'Ipswich', 'Isle of Man', 'Isle of Wight', 'Islington', 'Jersey', 'Kensington', 'Kent', 'Kettering', 'Kings Lynn', 'Kingston',
-    'Kirklees', 'Knowsley', 'Lake District', 'Lambeth', 'Lancashire', 'Lancaster', 'Larne', 'Leeds', 'Leicester', 'Leicestershire',
-    'Lewes', 'Lewisham', 'Lichfield', 'Limavady', 'Lincoln', 'Lincolnshire', 'Lisburn', 'Lisburn and Castlereagh', 'Liverpool', 'Loch Lomond',
-    'London', 'London Legacy', 'Luton', 'Magherafelt', 'Maidstone', 'Maldon', 'Malvern Hills', 'Manchester', 'Mansfield',
-    'Medway', 'Melton', 'Mendip', 'Merseyside', 'Merthyr Tydfil', 'Merton', 'Mid Devon', 'Mid East Antrim', 'Mid Kent', 'Mid Suffolk',
-    'Mid Sussex', 'Mid Ulster', 'Middlesbrough', 'Midlothian', 'Milton Keynes', 'Mole Valley', 'Monmouthshire', 'Moray', 'Moyle', 'Neath',
-    'New Forest (District)', 'New Forest (Park)', 'Newark and Sherwood', 'Newcastle under Lyme', 'Newcastle upon Tyne', 'Newham', 'Newport',
-    'Newry Mourne Down', 'Newry and Mourne', 'Newtownabbey', 'Norfolk', 'North Ayr', 'North Devon', 'North Dorset', 'North Down',
-    'North East', 'North East Derbyshire', 'North East Lincs', 'North Hertfordshire', 'North Kesteven', 'North Lanark', 'North Lincs',
-    'North Norfolk', 'North Somerset', 'North Tyneside', 'North Warwickshire', 'North West', 'North West Leicestershire', 'North Wiltshire',
-    'North York Moors', 'North Yorkshire', 'Northampton', 'Northamptonshire', 'Northern Ireland', 'Northumberland (County)',
-    'Northumberland (Park)', 'Norwich', 'Nottingham', 'Nottinghamshire', 'Nuneaton', 'Oadby and Wigston', 'Oldham', 'Omagh', 'Orkney',
-    'Oxford', 'Oxfordshire', 'Peak District', 'Pembroke Coast', 'Pembrokeshire', 'Pendle', 'Perth', 'Peterborough',
-    'Planning Inspectorate', 'Plymouth', 'Poole', 'Portsmouth', 'Powys', 'Preston', 'Purbeck', 'Reading', 'Redbridge', 'Redcar and Cleveland',
-    'Redditch', 'Reigate', 'Renfrew', 'Rhondda', 'Ribble Valley', 'Richmond', 'Richmondshire', 'Rochdale', 'Rochford', 'Rossendale',
-    'Rother', 'Rotherham', 'Rugby', 'Runnymede', 'Rushcliffe', 'Rushmoor', 'Rutland', 'Ryedale', 'Salford', 'Sandwell', 'Sark',
-    'Scarborough', 'Scilly Isles', 'Scotland', 'Scottish Borders', 'Sedgemoor', 'Sefton', 'Selby', 'Sevenoaks', 'Sheffield', 'Shepway',
-    'Shetlands', 'Shropshire', 'Slough', 'Snowdonia', 'Solihull', 'Somerset', 'South Ayr', 'South Bucks', 'South Cambridgeshire',
-    'South Derbyshire', 'South Downs', 'South East', 'South Gloucestershire', 'South Hams', 'South Holland', 'South Kesteven', 'South Lakeland',
-    'South Lanark', 'South Norfolk', 'South Northamptonshire', 'South Oxfordshire', 'South Ribble', 'South Somerset',
-    'South Staffordshire', 'South Tyneside', 'South West', 'South Wiltshire', 'South Yorkshire', 'Southampton', 'Southend', 'Southwark',
-    'Spelthorne', 'St Albans', 'St Edmundsbury', 'St Helens', 'Stafford', 'Staffordshire', 'Staffordshire Moorlands', 'Stevenage',
-    'Stirling', 'Stockport', 'Stockton-on-Tees', 'Stoke on Trent', 'Strabane', 'Stratford on Avon', 'Stroud', 'Suffolk', 'Suffolk Coastal',
-    'Sunderland', 'Surrey', 'Surrey Heath', 'Sutton', 'Swale', 'Swansea', 'Swindon', 'Tameside', 'Tamworth', 'Tandridge', 'Taunton Deane',
-    'Teignbridge', 'Telford', 'Tendring', 'Test Valley', 'Tewkesbury', 'Thanet', 'Three Rivers', 'Thurrock', 'Tonbridge', 'Torbay',
-    'Torfaen', 'Torridge', 'Tower Hamlets', 'Trafford', 'Tunbridge Wells', 'Tyne and Wear', 'United Kingdom', 'Uttlesford',
-    'Vale of White Horse', 'Wakefield', 'Wales', 'Walsall', 'Waltham Forest', 'Wandsworth', 'Warrington', 'Warwick', 'Warwickshire', 'Watford', 'Waveney',
-    'Waverley', 'Wealden', 'Wellingborough', 'Welwyn Hatfield', 'West Berkshire', 'West Devon', 'West Dorset', 'West Dunbarton',
-    'West Lancashire', 'West Lindsey', 'West Lothian', 'West Midlands', 'West Midlands County', 'West Oxfordshire', 'West Somerset',
-    'West Suffolk', 'West Sussex', 'West Wiltshire', 'West Yorkshire', 'Western Isles', 'Westminster', 'Weymouth', 'Wigan', 'Wiltshire',
-    'Winchester', 'Windsor', 'Wirral', 'Woking', 'Wokingham', 'Wolverhampton', 'Worcester', 'Worcestershire', 'Worthing', 'Wrexham',
-    'Wychavon', 'Wycombe', 'Wyre', 'Wyre Forest', 'York', 'Yorkshire Dales', 'Yorkshire and Humber',
-  ].freeze
 
   def initialize(end_date = (Date.today))
     @end_date = end_date
   end
 
   def process!
-    new_planning_applications = LOCAL_AUTHORITIES.map do |la|
+    new_planning_applications = PlanningFilter::LOCAL_AUTHORITIES.map do |la|
       get_authorty(la)
     end.flatten
     add_applications new_planning_applications

--- a/spec/lib/planning_application_worker_spec.rb
+++ b/spec/lib/planning_application_worker_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe PlanningApplicationWorker do
   before do
-    stub_const("#{described_class}::LOCAL_AUTHORITIES", ['London', 'Cambridge'] )
+    stub_const("PlanningFilter::LOCAL_AUTHORITIES", ['London', 'Cambridge'] )
   end
 
   let(:planning_record_alt) { planning_record.merge('uid' => '345') }
@@ -61,7 +61,7 @@ describe PlanningApplicationWorker do
 
   context 'with an authority with more than 500 planning applications' do
     before do
-      stub_const("#{described_class}::LOCAL_AUTHORITIES", ['Multi Page LA'] )
+      stub_const("PlanningFilter::LOCAL_AUTHORITIES", ['Multi Page LA'] )
     end
 
     let!(:multi_page_tot_req) do

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -97,30 +97,4 @@ describe PlanningApplication do
       expect{ described_class.remove_old }.to change{ described_class.count }.from(3).to(2)
     end
   end
-
-  describe '#relevant?' do
-    it 'should be true outside Cambridge' do
-      subject.authority_name = 'Leeds'
-      subject.save
-      expect(subject.relevant).to be true
-    end
-
-    %w(LBC FUL CL2PD PRP11 GPE NMA S73 0173 DEMDET REM B1C3 OUT TELDET EXP).each do |ending|
-      it "should be true with #{ending} uids inside Cambridge" do
-        subject.authority_name = 'Cambridge'
-        subject.uid = "00/0000/#{ending}"
-        subject.save
-        expect(subject.relevant).to be true
-      end
-    end
-
-    %w(TTCA TTPO COND3 COND53C CLUED ADV CON6 CON18).each do |ending|
-      it "should be flase with #{ending} uids inside Cambridge" do
-        subject.authority_name = 'Cambridge'
-        subject.uid = "00/0000/#{ending}"
-        subject.save
-        expect(subject.relevant).to be false
-      end
-    end
-  end
 end

--- a/spec/models/planning_filter_spec.rb
+++ b/spec/models/planning_filter_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe PlanningFilter, type: :model do
+  let(:planning_application) { build(:planning_application, uid: 'a/b/123') }
+
+  it 'is expected to have valid regex rules' do
+    subject.authority = 'West Yorkshire'
+    subject.rule = '[a]'
+    expect(subject).to be_valid
+    subject.rule = '[a'
+    expect(subject.errors_on(:rule)).to eq ['premature end of char-class: /[a/']
+  end
+
+  it 'filters irrelavant planning applications' do
+    subject.authority = planning_application.authority_name
+    subject.rule = '^a'
+    expect(subject.matches?(planning_application)).to be_truthy
+    subject.rule = '$a'
+    expect(subject.matches?(planning_application)).to be_falsey
+  end
+end

--- a/spec/models/planning_filter_spec.rb
+++ b/spec/models/planning_filter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe PlanningFilter, type: :model do
-  let(:planning_application) { build(:planning_application, uid: 'a/b/123') }
+  let(:planning_application) { build(:planning_application, uid: 'a/b/123', authority_name: 'West Yorkshire') }
 
   it 'is expected to have valid regex rules' do
     subject.authority = 'West Yorkshire'
@@ -17,5 +17,23 @@ describe PlanningFilter, type: :model do
     expect(subject.matches?(planning_application)).to be_truthy
     subject.rule = '$a'
     expect(subject.matches?(planning_application)).to be_falsey
+  end
+
+  describe 'star rules' do
+    subject { described_class.new(authority: described_class::STAR, rule: '[a]') }
+
+    context 'when la has a rule' do
+      before { described_class.create!(authority: planning_application.authority_name, rule: '[a]') }
+
+      it 'start does not match' do
+        expect(subject.matches?(planning_application)).to be_falsey
+      end
+    end
+
+    context 'when la no rules' do
+      it 'start does match' do
+        expect(subject.matches?(planning_application)).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds an admin interface to allow filtering planning application names by regex.
If no rules are associated with a region then they will be filtered by the * region.