### PR TITLE
Allow two word tags

### DIFF
--- a/config/locales/forms.en-GB.yml
+++ b/config/locales/forms.en-GB.yml
@@ -51,6 +51,8 @@
         new:
           bicycle_wheels: Bicycle Wheels
     hints:
+      tags_string_hints: &tags_string_hints
+        tags_string: comma seperated list of tags e.g. cycle parking, obstruction
       user:
         new: &hints_user_new
           display_name: If you set a display name, it will be shown to people who
@@ -98,8 +100,8 @@
           deadline: (optional)
           external_url: If another web page is relevant you can add it here.
           photo: optional
-          tags_string: e.g. cycle parking, obstruction, roadworks
           title: Please be brief and specific
+          <<: *tags_string_hints
         create: *hints_issue_new
         edit: *hints_issue_new
         update: *hints_issue_new
@@ -109,6 +111,8 @@
           none, this will be an administrative thread.
       library/note:
         url: If another web page is relevant you can add it here.
+        <<: *tags_string_hints
+      library/document: *tags_string_hints
     placeholders:
       issue:
         external_url: http://www.example.com

--- a/lib/taggable.rb
+++ b/lib/taggable.rb
@@ -61,8 +61,8 @@ module Taggable
   def tags_from_string(val)
     val.
       delete('#!()[]{}').
-      split(/[,; ]+/).
-      map { |str| str.parameterize }.
+      split(/[,]+/).
+      map { |str| str.parameterize.gsub(' ', '-') }.
       uniq.
       delete_if { |str| str == '' }.
       map { |str| Tag.grab(str) }

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -342,9 +342,9 @@ describe Issue do
     end
 
     it 'should be consistent with respect to tag order' do
-      subject.tags_string = "#{tag_with_icon.name} #{tag_with_icon2.name}"
+      subject.tags_string = "#{tag_with_icon.name},#{tag_with_icon2.name}"
       expect(subject.icon_from_tags).to eq(tag_with_icon.icon)
-      subject.tags_string = "#{tag_with_icon2.name} #{tag_with_icon.name}"
+      subject.tags_string = "#{tag_with_icon2.name},#{tag_with_icon.name}"
       expect(subject.icon_from_tags).to eq(tag_with_icon.icon)
     end
   end

--- a/spec/models/library/item_spec.rb
+++ b/spec/models/library/item_spec.rb
@@ -13,7 +13,7 @@ describe Library::Item do
   end
 
   context 'find by tags' do
-    let!(:item) { create(:library_item, tags_string: 'foo bar baz') }
+    let!(:item) { create(:library_item, tags_string: 'foo,bar,baz') }
     let!(:item2) { create(:library_item, tags_string: 'bananas') }
 
     it 'should return both notes' do

--- a/spec/support/shared_examples/taggable.rb
+++ b/spec/support/shared_examples/taggable.rb
@@ -2,17 +2,12 @@ shared_examples 'a taggable model' do
   it { is_expected.to have_and_belong_to_many(:tags) }
 
   context 'tags string' do
-    it 'should set and return' do
-      subject.tags_string = 'wheels pedals bell'
-      expect(subject.tags_string).to eq('wheels, pedals, bell')
+    it 'should set and return converting spaces to -' do
+      subject.tags_string = 'wheels pedals  bell'
+      expect(subject.tags_string).to eq('wheels-pedals-bell')
     end
 
     context 'tokenization' do
-      it 'should split on spaces' do
-        subject.tags_string = 'one two'
-        expect(subject.tags.size).to eq(2)
-      end
-
       it 'should split on commas' do
         subject.tags_string = 'one, two'
         expect(subject.tags.size).to eq(2)
@@ -25,13 +20,8 @@ shared_examples 'a taggable model' do
         expect(subject.tags.size).to eq(2)
       end
 
-      it 'should split on semi-colons' do
-        subject.tags_string = 'one;two;three'
-        expect(subject.tags.size).to eq(3)
-      end
-
       it 'should remove hash symbols' do
-        subject.tags_string = '#one #two'
+        subject.tags_string = '#one,#two'
         expect(subject.tags.size).to eq(2)
         expect(subject.tags[0].name).to eq('one')
         expect(subject.tags[1].name).to eq('two')
@@ -43,30 +33,30 @@ shared_examples 'a taggable model' do
       end
 
       it 'should remove parentheses' do
-        subject.tags_string = '(one) two('
+        subject.tags_string = '(one),two('
         expect(subject.tags.first.name).to eq('one')
         expect(subject.tags.second.name).to eq('two')
       end
 
       it 'should remove square brackets' do
-        subject.tags_string = '[one] two]'
+        subject.tags_string = '[one],two]'
         expect(subject.tags.first.name).to eq('one')
         expect(subject.tags.second.name).to eq('two')
       end
 
       it 'should remove curly braces' do
-        subject.tags_string = '{one} two{'
+        subject.tags_string = '{one},two{'
         expect(subject.tags.first.name).to eq('one')
         expect(subject.tags.second.name).to eq('two')
       end
 
       it 'should ignore duplicates' do
-        subject.tags_string = 'one one one'
+        subject.tags_string = 'one,one,one'
         expect(subject.tags.size).to eq(1)
       end
 
       it 'should ignore invalid chars' do
-        subject.tags_string = 'one = & two'
+        subject.tags_string = 'one =,& two'
         expect(subject.tags.size).to eq(2)
       end
     end


### PR DESCRIPTION
Split only on commas (as the js tagging lib does)
Convert spaces to - which keeps consistency
Fixes #574

@mvl22 thoughts?