### PR TITLE
Remove the Leaflet attribution prefix.

### DIFF
--- a/app/assets/javascripts/map_display.js.coffee.erb
+++ b/app/assets/javascripts/map_display.js.coffee.erb
@@ -10,6 +10,7 @@ jQuery ->
     constructor: (center, opts) ->
       @domId = opts.domid || 'map'
       @map = L.map(@domId, maxZoom: 18)
+      @map.attributionControl.setPrefix('')
       @setCenter(center)
       @geoInput = $("##{opts.geoinput}_loc_json")
       @buildCollistionLayer() if opts.collisions?


### PR DESCRIPTION
This remove the attribution prefix from the maps - it looks particularly bad when there's a long list of compact maps for example when showing lists of issues.