### PR TITLE
Improve leaflet icons

### DIFF
--- a/app/assets/javascripts/map_display.js.coffee.erb
+++ b/app/assets/javascripts/map_display.js.coffee.erb
@@ -24,7 +24,7 @@ jQuery ->
       @map.removeControl(@map.zoomControl) if opts.hidezoom?
 
     featurePointToLayer: (feature, latlng) =>
-      icon = new L.Icon.Default(iconUrl: feature.properties.thumbnail)
+      icon = new L.Icon(iconUrl: feature.properties.thumbnail)
       L.marker(latlng, {icon: icon}).addTo @map
 
     addStaticFeature: (collection) ->

--- a/app/assets/javascripts/map_display.js.coffee.erb
+++ b/app/assets/javascripts/map_display.js.coffee.erb
@@ -24,7 +24,7 @@ jQuery ->
       @map.removeControl(@map.zoomControl) if opts.hidezoom?
 
     featurePointToLayer: (feature, latlng) =>
-      icon = new L.Icon(iconUrl: feature.properties.thumbnail)
+      icon = new L.Icon(iconUrl: feature.properties.thumbnail, iconAnchor: feature.properties.anchor)
       L.marker(latlng, {icon: icon}).addTo @map
 
     addStaticFeature: (collection) ->

--- a/app/decorators/issue_decorator.rb
+++ b/app/decorators/issue_decorator.rb
@@ -43,6 +43,21 @@ class IssueDecorator < ApplicationDecorator
     h.image_path "map-icons/#{size}-#{icon}.png"
   end
 
+  # The position of the 'tip' of the icon, relative to the top-left corner [w, h].
+  # We could detect this from the images but this is quicker since they are all
+  # the same geometry.
+  def large_icon_anchor
+    [34 / 2, 54]
+  end
+
+  def medium_icon_anchor
+    [30 / 2, 42]
+  end
+
+  def small_icon_anchor
+    [19.to_f / 2, 26]
+  end
+
   def creator_link
     h.t 'issues.compact.created_by_html', creator_link: h.link_to_profile(issue.created_by)
   end

--- a/app/helpers/maps_helper.rb
+++ b/app/helpers/maps_helper.rb
@@ -14,7 +14,11 @@ module MapsHelper
   def item_to_geojson(decorated_item)
     return nil unless decorated_item.location
     collection = RGeo::GeoJSON::EntityFactory.new.feature_collection(
-      [RGeo::GeoJSON::Feature.new(decorated_item.location, nil, thumbnail: decorated_item.try(:medium_icon_path))]
+      [RGeo::GeoJSON::Feature.new(decorated_item.location,
+                                  nil,
+                                  thumbnail: decorated_item.try(:medium_icon_path),
+                                  anchor: decorated_item.try(:medium_icon_anchor)
+                                 )]
     )
     RGeo::GeoJSON.encode(collection)
   end


### PR DESCRIPTION
This fixes a couple of problems with the leaflet icons, including them appearing squashed (since they were using the size of the L.Icon.Default icon instead of automatic sizing).