### PR TITLE
Improve photo display sizes

### DIFF
--- a/app/decorators/issue_decorator.rb
+++ b/app/decorators/issue_decorator.rb
@@ -67,7 +67,7 @@ class IssueDecorator < ApplicationDecorator
 
   def standard_photo_url
     if photo
-      photo.thumb('358x200>').url
+      photo.thumb('360x540>').url
     end
   end
 end

--- a/app/models/messages/photo_message.rb
+++ b/app/models/messages/photo_message.rb
@@ -20,11 +20,11 @@ class PhotoMessage < MessageComponent
   validates :photo, presence: true
 
   def photo_medium
-    photo.thumb('600x600>')
+    photo.thumb('740x555>')
   end
 
   def photo_preview
-    photo.thumb('200x200>')
+    photo.thumb('500x375>')
   end
 
   def photo_thumbnail

--- a/spec/models/messages/photo_message_spec.rb
+++ b/spec/models/messages/photo_message_spec.rb
@@ -54,8 +54,8 @@ describe PhotoMessage do
 
     it 'should provide a preview size of the photo' do
       expect(subject.photo_preview).to be_truthy
-      expect(subject.photo_preview.width).to eq(182)
-      expect(subject.photo_preview.height).to eq(200)
+      expect(subject.photo_preview.width).to eq(342)
+      expect(subject.photo_preview.height).to eq(375)
     end
   end
 


### PR DESCRIPTION
This PR contains two improvements to the display of photos:

* Photos in photo messages are now wider, approximately as wide as possible within the message. The height is constrained to be roughly the same as a streetview message to prevent heigh portrait-orientated photos taking up too much vertical space
* Photos on issues are as wide as the sidebar, and only narrower than that when they are portrait and exceed 3:2 aspect ratio (i.e. when they are very tall).