### PR TITLE
Simplify length limits on issue titles

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -41,7 +41,7 @@ class Issue < ActiveRecord::Base
   has_many :threads, class_name: "MessageThread", after_add: :set_new_thread_defaults, inverse_of: :issue
   has_and_belongs_to_many :tags, join_table: "issue_tags"
 
-  validates :title, presence: true, length: { maximum: 254 }
+  validates :title, presence: true, length: { maximum: 255 }
   validates :description, presence: true
   validates :location, presence: true
   validates :size, numericality: { less_than: Geo::ISSUE_MAX_AREA }

--- a/app/views/issues/_form.html.haml
+++ b/app/views/issues/_form.html.haml
@@ -1,6 +1,6 @@
 = semantic_form_for @issue, html: {class: "guided"} do |f|
   = f.inputs do
-    = f.input :title, maxlenght: 254
+    = f.input :title
     = f.input :photo, as: :file
     = f.input :retained_photo, as: :hidden
     = f.input :loc_json, as: :hidden

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -56,6 +56,11 @@ describe 'Issues' do
           expect(page).to have_content(issue_values[:title])
         end
       end
+
+      it 'should limit the length of the title input field' do
+        maxlength = find_field('Title')['maxlength']
+        expect(maxlength).to eq("255")
+      end
     end
   end
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -17,7 +17,7 @@ describe Issue do
     end
   end
 
-  it { is_expected.to validate_length_of(:title).is_at_most(254) }
+  it { is_expected.to validate_length_of(:title).is_at_most(255) }
 
   describe 'newly created' do
     subject { create(:issue) }


### PR DESCRIPTION
* The database limit is 255, so use that in the model too
* maxlength was mistyped
* Formtastic already sets maxlength based on the column length

Given that formtastic automatically sets maxlength based on the column limits, we should look again at #603 - it shouldn't be possible to type more than 255 characters into the input field (i.e. the browser should stop you before submitting the form causes a problem).