### PR TITLE
take application name from settings

### DIFF
--- a/app/views/home/show.html.haml
+++ b/app/views/home/show.html.haml
@@ -1,6 +1,6 @@
 %article#content
   %section.top-box
-    %h1= t ".introduction_html"
+    %h1= t(".introduction_html", application_name: Rails.application.config.application_name)
   %section.center-box
     %h2= t ".center_box_title"
     .inner
@@ -14,8 +14,8 @@
 
 %aside#sidebar
   %section.homepage-groups
-    %h2= t ".groups_title"
-    %p= t ".groups_intro_html", groups_link: link_to(t(".find_local_groups"), groups_path)
+    %h2= t(".groups_title", application_name: Rails.application.config.application_name)
+    %p= t ".groups_intro_html", application_name: Rails.application.config.application_name, groups_link: link_to(t(".find_local_groups"), groups_path)
   %section.twitter
     = render partial: "twitter"
 

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -5,10 +5,10 @@
         %ul
           %li
             %a(href="https://www.facebook.com/CycleStreets" class="facebook")
-              = t(".facebook_page")
+              = t(".facebook_page", application_name: Rails.application.config.application_name)
           %li
             %a(href="https://twitter.com/cyclescape" class="twitter")
-              = t(".twitter_page")
+              = t(".twitter_page", application_name: Rails.application.config.application_name)
           %li
             %small= t(".github_page_link_html")
           %li
@@ -16,7 +16,7 @@
           %li
             %small= link_to t(".whats_new"), page_path("changelog")
           %li
-            %small= link_to t(".cyclescape_blog"), 'http://blog.cyclescape.org/'
+            %small= link_to t(".cyclescape_blog", application_name: Rails.application.config.application_name), 'http://blog.cyclescape.org/'
           %li
             %small= link_to t(".user_guide"), 'http://blog.cyclescape.org/guide/'
           %li

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,7 @@ module Cyclescape
     # Default notification e-mail from address
     config.default_email_from_domain = 'cyclescape.org'
     config.default_email_from = 'Cyclescape <info@cyclescape.org>'
+    config.application_name = 'Cyclescape'
 
     # Git info
     config.git_hash = `git rev-parse --short HEAD`.chomp

--- a/config/locales/cs-CZ.yml
+++ b/config/locales/cs-CZ.yml
@@ -624,19 +624,19 @@ cs-CZ:
       failure: Odmítnutí požadavku na založení místní skupiny se nezdařilo
   home:
     show:
-      introduction_html: Cyklisté sobě je nástroj na podporu místních skupin snažících
-        se o zlepšení podmínek pro jízdu na kole ve svém okolí.
+      introduction_html: "%{application_name} je nástroj na podporu místních skupin snažících
+        se o zlepšení podmínek pro jízdu na kole ve svém okolí."
       center_box_title: Zde můžete navrhnout, jak zlepšit podmínky pro jízdu na kole
       center_box_html: Neexistující cyklostezka? Překážka bránící v provozu? Chybějící
         cyklostojan? Nebo příklad, kde bylo něco uděláno správně?
       report_an_issue: Přidat podnět
       latest_discussions: Poslední diskuze
-      groups_title: Místní skupiny Cyklisté sobě
-      groups_intro_html: Portál Cyklisté sobě používají <strong>místní skupiny</strong>
+      groups_title: Místní skupiny %{application_name}
+      groups_intro_html: Portál %{application_name} používají <strong>místní skupiny</strong>
         v celém Česku. <strong>%{groups_link}</strong> ve vašem okolí a zjistěte jaké
         problémy se snaží řešit.
       find_local_groups: Najděte si místní skupiny
-      twitter_title: Cyclescape na Twitteru
+      twitter_title: "%{application_name} na Twitteru"
     guide:
       title: Jak funguje tento web
       box_1_title: Přidejte  podnět
@@ -783,11 +783,11 @@ cs-CZ:
       funding_from_and_created_by: Web Cyklisté sobě byl podpořen %{name}
       planning_application_data: Planning application data from PlanIt
       top_html: Zpět na začátek &uarr;
-      cyclescape_blog: Blog Cyclescape
+      cyclescape_blog: Blog %{application_name}
       privacy: Zásady ochrany osobních údajů
       user_guide: Uživatelská příručka
-      facebook_page: Stránka na Facebooku
-      twitter_page: Stránka na Twitteru
+      facebook_page: "%{application_name} na Facebooku"
+      twitter_page: "%{application_name} na Twitteru"
       osm_credit_html: Mapová data &copy; přispěvatelé <a href='http://www.openstreetmap.org'>
         OpenStreetMap</a>, dostupné pod <a href='http://www.opendatacommons.org/licenses/odbl'>Open
         Database Licence</a>.

--- a/config/locales/de-DE.yml
+++ b/config/locales/de-DE.yml
@@ -622,17 +622,17 @@ de-DE:
       failure: Ablehnen des Gruppenantrag fehlgeschlagen
   home:
     show:
-      introduction_html: Cyclescape ist ein Online-Kampagnen-Werkzeug für Fahrrad-Kampagnen-Gruppen
+      introduction_html: "%{application_name} ist ein Online-Kampagnen-Werkzeug für Fahrrad-Kampagnen-Gruppen"
       center_box_title: Berichte hier über Dein Fahrradthema
       center_box_html: Kein vorhandener Radweg? Hindernisse für Radfahrer? Zu wenig
         Fahrradparkplätze vorhanden? Oder auch ein Beispiel für gut gemachte Dinge?
       report_an_issue: "Über ein Thema Berichten"
       latest_discussions: Neueste Diskussionen
-      groups_title: Cyclescape Gruppen
+      groups_title: "%{application_name} Gruppen"
       groups_intro_html: |
-        Cyclescape wird von <strong>Fahrrad-Kampagnen-Gruppen</strong> quer durchs Land benutzt. <strong>%{groups_link}</strong> und schau Dir an woran sie gerade arbeiten.
+        %{application_name} wird von <strong>Fahrrad-Kampagnen-Gruppen</strong> quer durchs Land benutzt. <strong>%{groups_link}</strong> und schau Dir an woran sie gerade arbeiten.
       find_local_groups: Finde Gruppen in deiner Nähe
-      twitter_title: Cyclescape bei Twitter
+      twitter_title: "%{application_name} bei Twitter"
     guide:
       title: Wie Cyclescape funktioniert
       box_1_title: Berichte über ein Thema
@@ -784,11 +784,11 @@ de-DE:
       funding_from_and_created_by: Mittel aus und erstellt von %{name}
       planning_application_data: Planning application data from PlanIt
       top_html: Back to top &uarr;
-      cyclescape_blog: Cyclescape blog
+      cyclescape_blog: "%{application_name} blog"
       privacy: Datenschutzerklärung
       user_guide: Benutzeranleitung
-      facebook_page: CycleStreets Facebook-Seite
-      twitter_page: CycleStreets Twitterkonto
+      facebook_page: "%{application_name} Facebook-Seite"
+      twitter_page: "%{application_name} Twitterkonto"
       osm_credit_html: Map data &copy; <a href='http://www.openstreetmap.org'> OpenStreetMap</a>
         contributors, available under the <a href='http://www.opendatacommons.org/licenses/odbl'>Open
         Database Licence</a>.

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -523,21 +523,21 @@
       failure: Failed to reject group request
   home:
     show:
-      introduction_html: Cyclescape is an online campaigning toolkit for cycle campaign
-        groups around the UK
+      introduction_html: "%{application_name} is an online campaigning toolkit for cycle campaign
+        groups around the UK"
       center_box_title: Add your cycling issues here
       center_box_html: Non-existent cycle paths? Obstructions for cyclists? Lack of
         cycle parking? Or an example of something done right?
       report_an_issue: Create an issue
       latest_discussions: Latest Discussions
-      groups_title: Cyclescape Groups
-      groups_intro_html: 'Cyclescape is used by <strong>cycle campaign groups</strong>
+      groups_title: "%{application_name} Groups"
+      groups_intro_html: '%{application_name} is used by <strong>cycle campaign groups</strong>
         across the country. <strong>%{groups_link}</strong> and see what they''re
         working to fix.
 
 '
       find_local_groups: Find groups local to you
-      twitter_title: Cyclescape on Twitter
+      twitter_title: "%{application_name} on Twitter"
     guide:
       title: How Cyclescape Works
       box_1_title: Create cycling issues
@@ -685,11 +685,11 @@
       funding_from_and_created_by: Funding from and created by %{name}
       planning_application_data: Planning application data from PlanIt
       top_html: Back to top &uarr;
-      cyclescape_blog: Cyclescape blog
+      cyclescape_blog: "%{application_name} blog"
       privacy: Privacy Policy
       user_guide: User guide
-      facebook_page: CycleStreets Facebook page
-      twitter_page: CycleStreets Twitter account
+      facebook_page: "%{application_name} Facebook page"
+      twitter_page: "%{application_name} Twitter account"
       osm_credit_html: Map data &copy; <a href='http://www.openstreetmap.org'> OpenStreetMap</a>
         contributors, available under the <a href='http://www.opendatacommons.org/licenses/odbl'>Open
         Database Licence</a>.

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -621,18 +621,18 @@ es-MX:
       failure: Failed to reject group request
   home:
     show:
-      introduction_html: Cyclescape is an online campaigning toolkit for cycle campaign
-        groups around the UK
+      introduction_html: "%{application_name} is an online campaigning toolkit for cycle campaign
+        groups around the UK"
       center_box_title: Add your cycling issues here
       center_box_html: Non-existent cycle paths? Obstructions for cyclists? Lack of
         cycle parking? Or an example of something done right?
       report_an_issue: Create an issue
       latest_discussions: Latest Discussions
-      groups_title: Cyclescape Groups
+      groups_title: "%{application_name} Groups"
       groups_intro_html: |
-        Cyclescape is used by <strong>cycle campaign groups</strong> across the country. <strong>%{groups_link}</strong> and see what they're working to fix.
+        %{application_name} is used by <strong>cycle campaign groups</strong> across the country. <strong>%{groups_link}</strong> and see what they're working to fix.
       find_local_groups: Find groups local to you
-      twitter_title: Cyclescape on Twitter
+      twitter_title: "%{application_name} on Twitter"
     guide:
       title: How Cyclescape Works
       box_1_title: Create cycling issues
@@ -780,11 +780,11 @@ es-MX:
       funding_from_and_created_by: Funding from and created by %{name}
       planning_application_data: Planning application data from PlanIt
       top_html: Back to top &uarr;
-      cyclescape_blog: Cyclescape blog
+      cyclescape_blog: "%{application_name} blog"
       privacy: Privacy Policy
       user_guide: User guide
-      facebook_page: CycleStreets Facebook page
-      twitter_page: CycleStreets Twitter account
+      facebook_page: "%{application_name} Facebook page"
+      twitter_page: "%{application_name} Twitter account"
       osm_credit_html: Map data &copy; <a href='http://www.openstreetmap.org'> OpenStreetMap</a>
         contributors, available under the <a href='http://www.opendatacommons.org/licenses/odbl'>Open
         Database Licence</a>.

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -618,18 +618,18 @@ fr-CA:
       failure: Failed to reject group request
   home:
     show:
-      introduction_html: Cyclescape is an online campaigning toolkit for cycle campaign
-        groups around the UK
+      introduction_html: "%{application_name} is an online campaigning toolkit for cycle campaign
+        groups around the UK"
       center_box_title: Add your cycling issues here
       center_box_html: Non-existent cycle paths? Obstructions for cyclists? Lack of
         cycle parking? Or an example of something done right?
       report_an_issue: Create an issue
       latest_discussions: Latest Discussions
-      groups_title: Cyclescape Groups
+      groups_title: "%{application_name} Groups"
       groups_intro_html: |
-        Cyclescape is used by <strong>cycle campaign groups</strong> across the country. <strong>%{groups_link}</strong> and see what they're working to fix.
+        %{application_name} is used by <strong>cycle campaign groups</strong> across the country. <strong>%{groups_link}</strong> and see what they're working to fix.
       find_local_groups: Find groups local to you
-      twitter_title: Cyclescape on Twitter
+      twitter_title: "%{application_name} on Twitter"
     guide:
       title: How Cyclescape Works
       box_1_title: Create cycling issues
@@ -777,11 +777,11 @@ fr-CA:
       funding_from_and_created_by: Funding from and created by %{name}
       planning_application_data: Planning application data from PlanIt
       top_html: Back to top &uarr;
-      cyclescape_blog: Cyclescape blog
+      cyclescape_blog: "%{application_name} blog"
       privacy: Privacy Policy
       user_guide: User guide
-      facebook_page: CycleStreets Facebook page
-      twitter_page: CycleStreets Twitter account
+      facebook_page: "%{application_name} Facebook page"
+      twitter_page: "%{application_name} Twitter account"
       osm_credit_html: Map data &copy; <a href='http://www.openstreetmap.org'> OpenStreetMap</a>
         contributors, available under the <a href='http://www.opendatacommons.org/licenses/odbl'>Open
         Database Licence</a>.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -622,21 +622,21 @@ fr:
       failure: Failed to reject group request
   home:
     show:
-      introduction_html: Cyclescape is an online campaigning toolkit for cycle campaign
-        groups around the UK
+      introduction_html: "%{application_name} is an online campaigning toolkit for cycle campaign
+        groups around the UK"
       center_box_title: Add your cycling issues here
       center_box_html: Non-existent cycle paths? Obstructions for cyclists? Lack of
         cycle parking? Or an example of something done right?
       report_an_issue: Create an issue
       latest_discussions: Latest Discussions
-      groups_title: Cyclescape Groups
-      groups_intro_html: 'Cyclescape is used by <strong>cycle campaign groups</strong>
+      groups_title: "%{application_name} Groups"
+      groups_intro_html: '%{application_name} is used by <strong>cycle campaign groups</strong>
         across the country. <strong>%{groups_link}</strong> and see what they''re
         working to fix.
 
 '
       find_local_groups: Find groups local to you
-      twitter_title: Cyclescape on Twitter
+      twitter_title: "%{application_name} on Twitter"
     guide:
       title: How Cyclescape Works
       box_1_title: Create cycling issues
@@ -784,11 +784,11 @@ fr:
       funding_from_and_created_by: Funding from and created by %{name}
       planning_application_data: Planning application data from PlanIt
       top_html: Back to top &uarr;
-      cyclescape_blog: Cyclescape blog
+      cyclescape_blog: "%{application_name} blog"
       privacy: Privacy Policy
       user_guide: User guide
-      facebook_page: CycleStreets Facebook page
-      twitter_page: CycleStreets Twitter account
+      facebook_page: "%{application_name} Facebook page"
+      twitter_page: "%{application_name} Twitter account"
       osm_credit_html: Map data &copy; <a href='http://www.openstreetmap.org'> OpenStreetMap</a>
         contributors, available under the <a href='http://www.opendatacommons.org/licenses/odbl'>Open
         Database Licence</a>.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -622,21 +622,21 @@ it:
       failure: Failed to reject group request
   home:
     show:
-      introduction_html: Cyclescape is an online campaigning toolkit for cycle campaign
-        groups around the UK
+      introduction_html: "%{application_name} is an online campaigning toolkit for cycle campaign
+        groups around the UK"
       center_box_title: Add your cycling issues here
       center_box_html: Non-existent cycle paths? Obstructions for cyclists? Lack of
         cycle parking? Or an example of something done right?
       report_an_issue: Create an issue
       latest_discussions: Ultime discussioni
-      groups_title: Gruppi Cyclescape
-      groups_intro_html: 'Cyclescape is used by <strong>cycle campaign groups</strong>
+      groups_title: Gruppi %{application_name}
+      groups_intro_html: '%{application_name} is used by <strong>cycle campaign groups</strong>
         across the country. <strong>%{groups_link}</strong> and see what they''re
         working to fix.
 
 '
       find_local_groups: Find groups local to you
-      twitter_title: Cyclescape su Twitter
+      twitter_title: "%{application_name} su Twitter"
     guide:
       title: Come funziona Cyclescape
       box_1_title: Create cycling issues
@@ -784,11 +784,11 @@ it:
       funding_from_and_created_by: Funding from and created by %{name}
       planning_application_data: Planning application data from PlanIt
       top_html: Back to top &uarr;
-      cyclescape_blog: Cyclescape blog
+      cyclescape_blog: "%{application_name} blog"
       privacy: Privacy Policy
       user_guide: Guida utente
-      facebook_page: CycleStreets Facebook page
-      twitter_page: CycleStreets Twitter account
+      facebook_page: "%{application_name} Facebook page"
+      twitter_page: "%{application_name} Twitter account"
       osm_credit_html: Map data &copy; <a href='http://www.openstreetmap.org'> OpenStreetMap</a>
         contributors, available under the <a href='http://www.opendatacommons.org/licenses/odbl'>Open
         Database Licence</a>.


### PR DESCRIPTION
This is my attempt to address part of #482.

I would like to converge the locale of Cyclescape and Cyklisté sobě. The branding of the page should be loaded from config file instead of being spread through the entire locale.

The current state of this PR is only for demonstration purposes. I would like to get confirmation, that it is the right way before I will go full scale.

@nikolai-b Please look at this before I change it all across the system.