### PR TITLE
Unifiing messages, thread and issues API

### DIFF
--- a/app/api/route/issue_api.rb
+++ b/app/api/route/issue_api.rb
@@ -11,8 +11,8 @@ module Route
       optional :order, type: Symbol, values:%i( vote_count created_at start_at size id ), desc: 'Order of returned issues.'
       optional :order_direction, type: Symbol, values:%i(asc desc), default: :desc, desc: 'Ordering direction. Not working with "vote_count".'
       optional :id, type: Integer, desc: 'Issue ID'
-      optional :end_date, type: Date, desc: 'No issues after the end date are returned'
-      optional :start_date, type: Date, desc: 'No issues before the start date are returned'
+      optional :end_date, types: [DateTime, Date], desc: 'No issues after the end date are returned'
+      optional :start_date, types: [DateTime, Date], desc: 'No issues before the start date are returned'
       optional(:geo_collection,
                type: Array[RGeo::GeoJSON::Feature],
                desc: 'Return only issues inside this GeoJSON feature collection, e.g. {"type":"FeatureCollection","features":[{"type":"Polygon","coordinates":[[[-1.5724,53.795],[-1.54289,53.8083],[-1.54426,53.79010],[-1.5724,53.7957]]]}]}',

--- a/app/api/route/message_api.rb
+++ b/app/api/route/message_api.rb
@@ -4,8 +4,8 @@ module Route
 
     params do
       optional :thread_id, type: Integer, desc: 'ID of thread'
-      optional :order_by, type: Symbol, values:%i( created_at id  ), desc: 'Order of returned issues.'
-      optional :order, type: Symbol, values:%i(asc desc), default: :asc
+      optional :order, type: Symbol, values:%i( created_at id  ), desc: 'Order of returned issues.'
+      optional :order_direction, type: Symbol, values:%i(asc desc), default: :desc, desc: 'Ordering direction.'
     end
 
     helpers do
@@ -13,7 +13,7 @@ module Route
         scope = Message.joins(:thread).includes(:created_by)
         scope = scope.merge(MessageThread.is_public.approved)
         scope = scope.where(censored_at: nil)
-        scope = scope.order(params[:order_by] => params[:order]) if params[:order_by]
+        scope = scope.order(params[:order] => params[:order_direction]) if params[:order]
         scope = scope.where(thread_id: params[:thread_id]) if params[:thread_id]
         scope = paginate scope
       end

--- a/app/api/route/thread_api.rb
+++ b/app/api/route/thread_api.rb
@@ -5,8 +5,8 @@ module Route
     params do
       optional :group, type: String, desc: 'Return only issues from area of group given by its short name, e.g. "london"'
       optional :issue_id, type: Integer, desc: 'ID of issue'
-      optional :order_by, type: Symbol, values:%i( created_at id  ), desc: 'Order of returned issues.'
-      optional :order, type: Symbol, values:%i(asc desc), default: :asc
+      optional :order, type: Symbol, values:%i( created_at id  ), desc: 'Order of returned issues.'
+      optional :order_direction, type: Symbol, values:%i(asc desc), default: :desc, desc: 'Ordering direction.'
     end
 
     helpers do
@@ -17,7 +17,7 @@ module Route
           error! 'Given group not found', 404 unless group
           scope = scope.intersects(group.profile.location)
         end
-        scope = scope.order(params[:order_by] => params[:order]) if params[:order_by]
+        scope = scope.order(params[:order] => params[:order_direction]) if params[:order]
         scope = scope.where(issue_id: params[:issue_id]) if params[:issue_id]
         scope = paginate scope
       end


### PR DESCRIPTION
I tried to unify conventions between Issues API and new Messages/Threads API. I made data type of `issues.order` parameter to `Symbol` with defined set of values. I also unified ordering fields to `order` and `order_direction` to preserve Issues compatibility. The `end_date`/`start_date` in issues can now accept `DateTime`.