### PR TITLE
use application_name (almost) everywhere

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,7 +110,7 @@ class ApplicationController < ActionController::Base
   def set_page_title(title = nil, value = nil)
     key = "#{controller_path.tr("/", ".")}.#{params[:action]}.title"
     page_title = title || I18n.translate(key, (value || { default: '' }))
-    app_title = I18n.translate('application_name')
+    app_title = @site_config.application_name
     @page_title = page_title == '' ? app_title : "#{page_title} - #{app_title}"
   end
 

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -6,28 +6,28 @@ class Notifications < ActionMailer::Base
     @member = request.user
     @group = request.group
     mail(to: @member.name_with_email,
-         subject: t('mailers.notifications.gmr_confirmed.subject', group_name: @group.name))
+         subject: t('mailers.notifications.gmr_confirmed.subject', group_name: @group.name, application_name: @site_config.application_name))
   end
 
   def new_group_request(request, admins_ids)
     @request = request
     mail(to: User.where(id: admins_ids).map(&:email),
          subject: t('mailers.notifications.new_group_request.subject',
-                    group_name: @request.name, user_name: @request.user.full_name))
+                    group_name: @request.name, user_name: @request.user.full_name, application_name: @site_config.application_name))
   end
 
   def group_request_confirmed(group, request)
     @user = request.user
     @group = group
     mail(to: @user.email,
-         subject: t('mailers.notifications.group_request_confirmed.subject', group_name: @group.name))
+         subject: t('mailers.notifications.group_request_confirmed.subject', group_name: @group.name, application_name: @site_config.application_name))
   end
 
   def group_request_rejected(request)
     @request = request
     user = request.user
     mail(to: user.email,
-         subject: t('mailers.notifications.group_request_rejected.subject', group_request_name: @request.name))
+         subject: t('mailers.notifications.group_request_rejected.subject', group_request_name: @request.name, application_name: @site_config.application_name))
   end
 
   def new_group_membership_request(request)
@@ -42,7 +42,7 @@ class Notifications < ActionMailer::Base
                       end
       if email_address
         mail to: email_address,
-             subject: t('mailers.notifications.new_gmr.subject', user_name: @user.name, group_name: @group.name)
+             subject: t('mailers.notifications.new_gmr.subject', user_name: @user.name, group_name: @group.name, application_name: @site_config.application_name)
       end
     end
   end
@@ -54,7 +54,7 @@ class Notifications < ActionMailer::Base
     body = Mustache.render(@group.profile.new_user_email, full_name: @member.full_name) if @group.profile.new_user_email
     mail(
       to: @member.name_with_email,
-      subject: t('mailers.notifications.added_to_group.subject', group_name: @group.name),
+      subject: t('mailers.notifications.added_to_group.subject', group_name: @group.name, application_name: @site_config.application_name),
       body: body,
     )
   end
@@ -71,7 +71,7 @@ class Notifications < ActionMailer::Base
          from: user_notification_address(@message_author),
          reply_to: message_address(message),
          subject: t('mailers.notifications.new_group_thread.subject',
-                    group_name: @group.name, thread_title: @thread.title)
+                    group_name: @group.name, thread_title: @thread.title, application_name: @site_config.application_name)
   end
 
   def new_user_location_issue(user_location, issue)
@@ -79,7 +79,7 @@ class Notifications < ActionMailer::Base
     @user_location = user_location
     mail to: @user_location.user.name_with_email,
          subject: t('mailers.notifications.new_user_location_issue.subject',
-                    issue_title: @issue.title)
+                    issue_title: @issue.title, application_name: @site_config.application_name)
   end
 
   # Send a notification to a user that a thread has started on an issue in their area
@@ -93,7 +93,7 @@ class Notifications < ActionMailer::Base
          from: user_notification_address(@message.created_by),
          reply_to: message_address(@message),
          subject: t('mailers.notifications.new_user_location_issue_thread.subject',
-                    issue_title: @thread.issue.title)
+                    issue_title: @thread.issue.title, application_name: @site_config.application_name)
   end
 
   def new_group_location_issue(user, group, issue)
@@ -102,13 +102,13 @@ class Notifications < ActionMailer::Base
     @issue = issue
     mail to: @user.name_with_email,
          subject: t('mailers.notifications.new_group_location_issue.subject',
-                    group_name: @group.name, issue_title: @issue.title)
+                    group_name: @group.name, issue_title: @issue.title, application_name: @site_config.application_name)
   end
 
   def new_user_confirmed(user)
     @user = user
     mail to: @user.name_with_email,
-         subject: t('mailers.notifications.new_user_confirmed.subject')
+         subject: t('mailers.notifications.new_user_confirmed.subject', application_name: @site_config.application_name)
   end
 
   def upcoming_issue_deadline(user, issue, thread)
@@ -116,7 +116,7 @@ class Notifications < ActionMailer::Base
     @issue = issue
     @thread = thread
     mail to: @user.name_with_email,
-         subject: t('mailers.notifications.upcoming_issue_deadline.subject', issue_title: @issue.title)
+         subject: t('mailers.notifications.upcoming_issue_deadline.subject', issue_title: @issue.title, application_name: @site_config.application_name)
   end
 
   def upcoming_thread_deadline(user, thread, deadline_message)
@@ -125,6 +125,6 @@ class Notifications < ActionMailer::Base
     @deadline_message = deadline_message
     mail to: @user.name_with_email,
       reply_to: message_address(deadline_message.message),
-      subject: t('mailers.notifications.upcoming_thread_deadline.subject', thread_title: @thread.title)
+      subject: t('mailers.notifications.upcoming_thread_deadline.subject', thread_title: @thread.title, application_name: @site_config.application_name)
   end
 end

--- a/app/mailers/thread_mailer.rb
+++ b/app/mailers/thread_mailer.rb
@@ -9,7 +9,7 @@ class ThreadMailer < ActionMailer::Base
 
     mail(
       to: @subscriber.name_with_email,
-      subject: t('mailers.thread_mailer.digest.subject', date: Date.current.to_s(:long)),
+      subject: t('mailers.thread_mailer.digest.subject', date: Date.current.to_s(:long), application_name: @site_config.application_name),
       reply_to: no_reply_address,
     )
   end
@@ -31,7 +31,7 @@ class ThreadMailer < ActionMailer::Base
                                      content: cal.to_ical }
     end
     mail(to: subscriber.name_with_email,
-         subject: t(subject, title: @thread.title, count: @thread.messages.count),
+         subject: t(subject, title: @thread.title, count: @thread.messages.count, application_name: @site_config.application_name),
          from: user_notification_address(message.created_by),
          references: message_chain(@message.in_reply_to, @thread),
          message_id: message_address(@message),

--- a/app/views/devise/invitations/edit.html.haml
+++ b/app/views/devise/invitations/edit.html.haml
@@ -1,5 +1,5 @@
 .edit-user-form
-  %h1= t ".title"
+  %h1= t(".title", application_name: @site_config.application_name)
   %p
     = t ".info"
   = semantic_form_for resource, as: resource_name, url: invitation_path(resource_name), html: {method: :put} do |f|

--- a/app/views/group/members/index.html.haml
+++ b/app/views/group/members/index.html.haml
@@ -6,7 +6,7 @@
 %p= t ".new_members_guidance_introduction"
 %ul.bullets
   %li= t ".new_members_guidance_method1_html", add_directly_link: link_to(t(".add_directly"), new_group_membership_path)
-  %li= t ".new_members_guidance_method2_html"
+  %li= t(".new_members_guidance_method2_html", application_name: @site_config.application_name)
 
 
 - if @pending_requests

--- a/app/views/group/membership_requests/new.html.haml
+++ b/app/views/group/membership_requests/new.html.haml
@@ -7,7 +7,7 @@
 = semantic_form_for @request do |f|
   = f.semantic_errors
   = f.inputs do
-    = f.input :message
+    = f.input :message, placeholder: t("formtastic.placeholders.group_membership_request.message", application_name: @site_config.application_name)
   = f.actions do
     = f.action :submit, button_html: {class: "btn-green submit"}
     = cancel_link group_path(@group)

--- a/app/views/group/memberships/new.html.haml
+++ b/app/views/group/memberships/new.html.haml
@@ -7,7 +7,7 @@
       = f2.semantic_errors
       = f2.inputs do
         = f2.input :full_name, hint: t("formtastic.hints.group_membership.full_name")
-        = f2.input :email, hint: t("formtastic.hints.group_membership.email")
+        = f2.input :email, hint: t("formtastic.hints.group_membership.email", application_name: @site_config.application_name)
     = f.input :role, :as => :radio, :collection => f.object.class.allowed_roles_map
   = f.actions do
     = f.action :submit

--- a/app/views/group/prefs/_form.html.haml
+++ b/app/views/group/prefs/_form.html.haml
@@ -1,5 +1,5 @@
 = semantic_form_for @prefs, url: [@prefs.group, :prefs] do |f|
   = f.inputs do
-    = f.input :notify_membership_requests
+    = f.input :notify_membership_requests, hint: t("formtastic.hints.group_pref.notify_membership_requests", application_name: @site_config.application_name)
     = f.input :membership_secretary, collection: @membership_secretary_candidates.map{ |msc| [msc.name, msc.id] }
   = f.actions

--- a/app/views/group/profiles/_form.html.haml
+++ b/app/views/group/profiles/_form.html.haml
@@ -7,6 +7,6 @@
       = render partial: "shared/edit_map", locals: {resource: @profile, location: @start_location}
     = f.input :picture, as: :file
     = f.input :retained_picture, as: :hidden
-    = f.input :joining_instructions
-    = f.input :new_user_email
+    = f.input :joining_instructions, hint: t("formtastic.hints.group_profile.joining_instructions", application_name: @site_config.application_name)
+    = f.input :new_user_email, placeholder: t("formtastic.placeholders.group_profile.new_user_email", application_name: @site_config.application_name, application_domain: @site_config.email_domain)
   = f.actions

--- a/app/views/group_requests/_form.html.haml
+++ b/app/views/group_requests/_form.html.haml
@@ -1,7 +1,7 @@
 = semantic_form_for @request, html: {class: 'guided'} do |f|
   = f.inputs do
     = f.input :name
-    = f.input :short_name, input_html: { style: "width:110px;" }
+    = f.input :short_name, input_html: { style: "width:110px;" }, label: t("formtastic.labels.group_request.short_name", application_name: @site_config.application_name)
     = f.input :website, placeholder: 'http:// ...'
     = f.input :email
     = f.input :message, input_html: { rows: "2", style: 'height:auto;' }

--- a/app/views/groups/_join.html.haml
+++ b/app/views/groups/_join.html.haml
@@ -1,7 +1,7 @@
 - if group.profile.joining_instructions
   %p= auto_link simple_format group.profile.joining_instructions.truncate(100)
 - else
-  %p= t ".join_body", group: group.name
+  %p= t(".join_body", group: group.name, application_name: @site_config.application_name)
 
 - if current_user && current_user.membership_request_pending_for?(group)
   %p= t ".group_request_pending"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,8 +16,8 @@
       %meta{name: "description", content: page_description}
       %meta{property: "og:description", content: page_description}
     - if page_title
-      %meta{property: "og:title", content: page_title.gsub(" - #{t('application_name')}", "")}
-    %meta{property: "og:site_name", content: t('application_name')}
+      %meta{property: "og:title", content: page_title.gsub(" - #{@site_config.application_name}", "")}
+    %meta{property: "og:site_name", content: @site_config.application_name}
 
   %body{class: [Rails.env, controller_path.tr("/_", "-")].join(" ")}
     #fb-root

--- a/app/views/thread_mailer/_footer.text.erb
+++ b/app/views/thread_mailer/_footer.text.erb
@@ -1,6 +1,6 @@
 
 --------
-<%= t ".thread" %>:
+<%= t(".thread", application_name: @site_config.application_name) %>:
 <% if defined?(@message) %>
   <%= thread_url(@thread, anchor: dom_id(@message)) %>
 <% else %>

--- a/config/locales/cs-CZ.yml
+++ b/config/locales/cs-CZ.yml
@@ -1,6 +1,5 @@
 ---
 cs-CZ:
-  application_name: Cyklisté sobě
   tags:
     show:
       heading: Položky označené jako '%{name}'

--- a/config/locales/devise.en-GB.yml
+++ b/config/locales/devise.en-GB.yml
@@ -34,7 +34,7 @@ en-GB:
     invitations:
       edit:
         title: Confirm your account
-        info: You have been invited to join Cyclescape, please complete your account
+        info: You have been invited to join %{application_name}, please complete your account
           registration including creating a password so that you can login. You can
           change your name and email address to the one that you prefer to use for
           this site.

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1,5 +1,4 @@
 "en-GB":
-  application_name: Cyclescape
   tags:
     show:
       heading: Things tagged '%{name}'
@@ -327,7 +326,7 @@
         ordinary_members: Ordinary members
         new_members_guidance_introduction: 'To add a member:'
         new_members_guidance_method1_html: If you know their email address, %{add_directly_link}.
-        new_members_guidance_method2_html: If they are already using Cyclescape, click
+        new_members_guidance_method2_html: If they are already using %{application_name}, click
           on their name from within a discussion thread, and you can add them from
           their user profile page.
         ordinary_members_guidance: Ordinary members get access to your private group
@@ -465,7 +464,7 @@
       already_member: You are already a member of this group
       no_location: This group doesn't have a location yet.
     join:
-      join_body: You can request membership of this Cyclescape group, if you want
+      join_body: You can request membership of this %{application_name} group, if you want
         to be involved in the %{group} activities.
       join_this_group: Join this group
       group_request_pending: Your request to join this group is pending.
@@ -760,41 +759,41 @@
         "
     notifications:
       added_to_group:
-        subject: You are now a member of the Cyclescape group for %{group_name}
+        subject: You are now a member of the %{application_name} group for %{group_name}
       gmr_confirmed:
-        subject: You are now a member of the Cyclescape group for %{group_name}
+        subject: You are now a member of the %{application_name} group for %{group_name}
       new_group_request:
-        subject: '[Cyclescape] [Admin] New Group "%{group_name}" has been requested by "%{user_name}"'
+        subject: '[%{application_name}] [Admin] New Group "%{group_name}" has been requested by "%{user_name}"'
       new_gmr:
-        subject: '[Cyclescape] [Committee] %{user_name} wants to join %{group_name}'
+        subject: '[%{application_name}] [Committee] %{user_name} wants to join %{group_name}'
       new_group_thread:
-        subject: '[Cyclescape] "%{thread_title}" (%{group_name})'
+        subject: '[%{application_name}] "%{thread_title}" (%{group_name})'
       new_group_location_issue:
-        subject: '[Cyclescape] New issue - "%{issue_title}" (%{group_name})'
+        subject: '[%{application_name}] New issue - "%{issue_title}" (%{group_name})'
       new_user_location_issue:
-        subject: '[Cyclescape] New issue - "%{issue_title}"'
+        subject: '[%{application_name}] New issue - "%{issue_title}"'
       new_user_location_issue_thread:
-        subject: '[Cyclescape] New thread started on issue "%{issue_title}"'
+        subject: '[%{application_name}] New thread started on issue "%{issue_title}"'
       group_request_confirmed:
-        subject: '[Cyclescape] [Admin] New Group "%{group_name}" has been created'
+        subject: '[%{application_name}] [Admin] New Group "%{group_name}" has been created'
       group_request_rejected:
-        subject: '[Cyclescape] [Admin] New Group "%{group_request_name}" has been not been created'
+        subject: '[%{application_name}] [Admin] New Group "%{group_request_name}" has been not been created'
       new_user_confirmed:
-        subject: '[Cyclescape] Welcome to Cyclescape'
+        subject: '[%{application_name}] Welcome to %{application_name}'
       upcoming_issue_deadline:
-        subject: '[Cyclescape] Upcoming deadline/date for "%{issue_title}"'
+        subject: '[%{application_name}] Upcoming deadline/date for "%{issue_title}"'
       upcoming_thread_deadline:
-        subject: '[Cyclescape] Upcoming deadline/date for "%{thread_title}"'
+        subject: '[%{application_name}] Upcoming deadline/date for "%{thread_title}"'
     thread_mailer:
       common:
         subject:
-          one: '[Cyclescape] %{title}'
-          other: 'Re: [Cyclescape] %{title}'
+          one: '[%{application_name}] %{title}'
+          other: 'Re: [%{application_name}] %{title}'
         committee_subject:
-          one: '[Cyclescape] [Committee] %{title}'
-          other: 'Re: [Cyclescape] [Committee] %{title}'
+          one: '[%{application_name}] [Committee] %{title}'
+          other: 'Re: [%{application_name}] [Committee] %{title}'
       digest:
-        subject: '[Cyclescape] Digest for %{date}'
+        subject: '[%{application_name}] Digest for %{date}'
   message_thread:
     subscriptions:
       create:
@@ -1136,7 +1135,7 @@
       new_leader: "%{leader_link} set themself as a leader of %{thread_title}."
       removed_leader: "%{leader_link} has removed themself as a leader of %{thread_title}."
     footer:
-      thread: Cyclescape discussion thread
+      thread: "%{application_name} discussion thread"
       unsubscribe: You can stop following this thread by visiting
   thread_priorities:
     very_high: Top-priority

--- a/config/locales/forms.en-GB.yml
+++ b/config/locales/forms.en-GB.yml
@@ -10,7 +10,7 @@
         short_name: Subdomain
       group_request:
         name: Name of the group
-        short_name: The proposed Cyclescape web address
+        short_name: The proposed %{application_name} web address
         website: Your organisation's main website
         email: Your organisation's main e-mail address
         default_thread_privacy: Default privacy for discussion threads
@@ -76,25 +76,25 @@
         short_name: Must be lower-case or numbers
         message: A short message to explain the group (helps us stop spam requests)
       group_membership:
-        email: Please enter their email. If this matches an existing Cyclescape account
+        email: Please enter their email. If this matches an existing %{application_name} account
           they will be added to the group immediately. Otherwise an invitation to
-          join Cyclescape will be sent to this address.
+          join %{application_name} will be sent to this address.
         full_name: Please enter their name; they can change this later.
         role: Select if they are a normal or committee member of the group.
       group_membership_request:
         message: You can optionally send the group administrators any additional information
           you feel is appropriate, such as a group membership number.
       group_pref:
-        notify_membership_requests: Notifications will be sent when a Cyclescape user
+        notify_membership_requests: Notifications will be sent when a %{application_name} user
           asks to join this group
         membership_secretary: Choose an optional membership secretary who will receive
           membership notification emails. Leave blank for notifications to be sent
           to the group email address.
       group_profile:
         joining_instructions: The joining instructions are shown to people who want
-          to join this Cyclescape group. You might want to direct people to pay for
+          to join this %{application_name} group. You might want to direct people to pay for
           membership elsewhere first, for example, or you might be happy for everyone
-          and anyone to join your Cyclescape group. You can leave this blank.
+          and anyone to join your %{application_name} group. You can leave this blank.
         new_user_email: This will be emailed to every new member, {{full_name}} will
           be converted to the person's full name in the email
         picture: To be displayed on the group page, ideally 333x192 pixels
@@ -130,12 +130,12 @@
       issue:
         external_url: http://www.example.com
       group_membership_request:
-        message: Please add me to the Cyclescape group.
+        message: Please add me to the %{application_name} group.
       library/note:
         url: http://www.example.com
       group_profile:
-        new_user_email: Hello {{full_name}}, you have been added to a Cyclescape group
-          http://www.cyclescape.org
+        new_user_email: Hello {{full_name}}, you have been added to a %{application_name} group
+          http://www.%{application_domain}
     actions:
       update: Save
       saving: Saving…


### PR DESCRIPTION
I almost finished work on usage of `application_name` site config.

I didn't manage to run mailing on my `development` server, so the notifications and the invitations page are not tested.

There is also one place left. On `group_profiles.default_new_user_email` I couldn't get `@site_config`.

It would be easy to replace `Cyclescape` with `%{application_name}` in all locale files. Should I include it, or it will not get to Transifex?