### PR TITLE
fix untranslatable strings

### DIFF
--- a/app/views/message/cyclestreets_photos/_new.html.haml
+++ b/app/views/message/cyclestreets_photos/_new.html.haml
@@ -11,7 +11,7 @@
           "data-opts" => { feature: item_to_geojson(@issue), photoselect: true, hidelayers: true, domid: "photo-map" }.to_json}
       = f.input :caption
       %li.string.input.optional.stringish
-        = label_tag 'image', nil, class: 'label'
+        = label_tag t('.image'), nil, class: 'label'
         %span{id: 'image-preview'}
 
     = f.actions do

--- a/app/views/message_threads/show.html.haml
+++ b/app/views/message_threads/show.html.haml
@@ -8,7 +8,7 @@
     - if @issue
       %p.pre-title= link_to @issue.title, issue_path(@issue)
     %p.thread-number
-      Thread
+      = t ".thread"
       %br/
       = @thread.display_id
     %h1= @thread.display_title

--- a/config/locales/cs-CZ.yml
+++ b/config/locales/cs-CZ.yml
@@ -985,6 +985,7 @@ cs-CZ:
         vidět a přispívat do tohoto vlákna.'
       private_html: Soukromá zprava mezi %{creator} a %{message_to}.
       public_message: 'Veřejné: Každý může vidět toto vlákno a vkládat do něj příspěvky.'
+      thread: Vlákno
     subscribe_panel:
       subscribed: Sledujete toto vlákno.
     subscribers_panel:
@@ -1036,6 +1037,8 @@ cs-CZ:
       show:
         photo_alt: 'Titulek fotografie: %{caption}.'
         view_original_image: Zobrazit původní obrázek
+      new:
+        image: Obrázek
     street_views:
       create:
         failure: Street View nebyl vytvořen

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -877,6 +877,7 @@
         messages to this thread.'
       private_html: Private Message between %{creator} and %{message_to}.
       public_message: 'Public: Everyone can view this thread and post messages.'
+      thread: Thread
     subscribe_panel:
       subscribed: You are following this thread.
     subscribers_panel:
@@ -919,6 +920,8 @@
       show:
         photo_alt: A photo entitled %{caption}.
         view_original_image: View the original image
+      new:
+        image: Image
     cyclestreets_photos:
       <<: *photo_message
     street_views:

--- a/config/locales/forms.cs-CZ.yml
+++ b/config/locales/forms.cs-CZ.yml
@@ -28,6 +28,7 @@ cs-CZ:
           photo: Přidejte fotografii
           tags_string: Přidejte štítek k vašemu podnětu
           title: Zvolte nadpis vašeho podnětu
+          all_day: Celý den
         create:
           description: Prosím, podrobnosti o problému a jaký vliv to má na cyklistiku.
             Pamatujte si, že všechny problémy jsou veřejně zobrazitelné. Na další
@@ -36,6 +37,7 @@ cs-CZ:
           photo: Přidejte fotografii
           tags_string: Přidejte štítek k vašemu podnětu
           title: Zvolte nadpis vašeho podnětu
+          all_day: Celý den
         edit:
           description: Prosím, podrobnosti o problému a jaký vliv to má na cyklistiku.
             Pamatujte si, že všechny problémy jsou veřejně zobrazitelné. Na další
@@ -44,6 +46,7 @@ cs-CZ:
           photo: Přidejte fotografii
           tags_string: Přidejte štítek k vašemu podnětu
           title: Zvolte nadpis vašeho podnětu
+          all_day: Celý den
         update:
           description: Prosím, podrobnosti o problému a jaký vliv to má na cyklistiku.
             Pamatujte si, že všechny problémy jsou veřejně zobrazitelné. Na další
@@ -52,6 +55,7 @@ cs-CZ:
           photo: Přidejte fotografii
           tags_string: Přidejte štítek k vašemu podnětu
           title: Zvolte nadpis vašeho podnětu
+          all_day: Celý den
       library/document:
         file: Dokument
       library/item: 
@@ -59,8 +63,24 @@ cs-CZ:
         location: Oblast významu
         body: Poznámka
         url: Webová adresa
+        title: Nadpis
+        description: Popis
+      deadline_message:
+        all_day: Celý den
+        title: Nadpis
+      photo_message:
+        caption: Nadpis
+        photo: Fotografie
+      street_view_message:
+        caption: Nadpis
+      cyclestreets_photo_message:
+        caption: Nadpis
+      document_message:
+        title: Nadpis
+        file: Soubor
       link_message:
         url: Webová adresa
+        description: Popis
       message:
         body: Zpráva
       site_comment:
@@ -74,11 +94,23 @@ cs-CZ:
         involve_my_groups_admin: Taktéž mě zahrňte do všeobecných diskuzí mých místních
           skupin
       user:
+        new: &labels_user_new
+          display_name: Zobrazené jméno
+          full_name: Plné jméno
+          email: E-mail
+          password: Heslo
+          password_confirmation: Potvrzení hesla
+          about: O profilu
+          bicycle_wheels: Kola u jízdních kol
+        create: *labels_user_new
         edit:
+          full_name: Plné jméno
+          display_name: Zobrazené jméno
+          email: E-mail
           password: Nové heslo
           password_confirmation: Potvrzení nového hesla
-        new:
-          bicycle_wheels: Kola u jízdních kol
+          current_password: Stávající heslo
+        update: *labels_user_new
     hints:
       tags_string_hints:
         tags_string: 'čárkou oddělený seznam štítků např.: cyklistický stojan, překážka'
@@ -229,6 +261,10 @@ cs-CZ:
         create: Odeslat zprávu
       photo_message:
         create: Přidat fotografii
+      cyclestreets_photo_message:
+        create: Přidat fotografii z CycleStreets
+      street_view_message:
+        create: Přidat pohled ze Street view
       site_comment:
         create: Zaslat zpětnou vazbu
       user:

--- a/config/locales/forms.en-GB.yml
+++ b/config/locales/forms.en-GB.yml
@@ -25,6 +25,7 @@
           photo: Add a photo
           tags_string: Tag your issue
           title: Title your report
+          all_day: All day
         create: *labels_issue_new
         edit: *labels_issue_new
         update: *labels_issue_new
@@ -35,8 +36,25 @@
         location: Area of relevance
         body: Note
         url: Web address
+        title: Title
+        description: Description
+      deadline_message:
+        all_day: All day
+        title: Title
+      photo_message:
+        caption: Caption
+        photo: Photo
+      street_view_message:
+        caption: Caption
+      cyclestreets_photo_message:
+        caption: Caption
+        image: Obrázek
+      document_message:
+        title: Title
+        file: File
       link_message:
         url: Web address
+        description: Description
       message:
         body: Message
       site_comment:
@@ -49,11 +67,23 @@
         involve_my_groups: My group's matters
         involve_my_groups_admin: Also involve me in my group's administrative discussions
       user:
+        new: &labels_user_new
+          display_name: Display name
+          full_name: Full name
+          email: E-mail
+          password: Password
+          password_confirmation: Password Confirmation
+          about: About
+          bicycle_wheels: Bicycle wheels
+        create: *labels_user_new
         edit:
+          display_name: Display name
+          full_name: Full name
+          email: E-mail
           password: New Password
           password_confirmation: New Password Confirmation
-        new:
-          bicycle_wheels: Bicycle Wheels
+          current_password: Current password
+        update: *labels_user_new
     hints:
       tags_string_hints: &tags_string_hints
         tags_string: comma separated list of tags e.g. cycle parking, obstruction
@@ -168,6 +198,10 @@
         create: Post Message
       photo_message:
         create: Add Photo
+      cyclestreets_photo_message:
+        create: Add CycleStreets Photo
+      street_view_message:
+        create: Add StreetView Message
       site_comment:
         create: Send Feedback
       user:


### PR DESCRIPTION
I have tried to add untranslatable form strings to `forms.en-GB` (but also in `forms.cs-CZ`) locale. I also added few translations through `t` function.

I didn't manage to do this in all places. I.E. I don't know how to create path for form labels on `/settings/profile` page.