### PR TITLE
Remove internal fields from API

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -108,10 +108,7 @@ class Message < ActiveRecord::Base
       body: body,
       created_at: created_at,
       updated_at: updated_at,
-      censored_at: censored_at,
-      deleted_at: deleted_at,
       public_token: public_token,
-      status: status,
       in_reply_to_id: in_reply_to_id,
     }
   end

--- a/app/models/message_thread.rb
+++ b/app/models/message_thread.rb
@@ -323,7 +323,7 @@ class MessageThread < ActiveRecord::Base
       id: id,
       issue_id: issue_id,
       created_by_id: created_by_id,
-      created_by_name: created_by.profile.visibility == 'public' ? created_by.name : created_by.display_name_or_anon,
+      created_by_name: created_by.profile.visibility == 'public' ? created_by.name : created_by.display_name,
       group_id: group_id,
       title: title,
       public_token: public_token,

--- a/app/models/message_thread.rb
+++ b/app/models/message_thread.rb
@@ -323,15 +323,12 @@ class MessageThread < ActiveRecord::Base
       id: id,
       issue_id: issue_id,
       created_by_id: created_by_id,
-      created_by_name: created_by.profile.visibility == 'public' ? created_by.name : nil,
+      created_by_name: created_by.profile.visibility == 'public' ? created_by.name : created_by.display_name_or_anon,
       group_id: group_id,
       title: title,
       public_token: public_token,
       created_at: created_at,
       updated_at: updated_at,
-      deleted_at: deleted_at,
-      status: status,
-      privacy: privacy,
       closed: closed,
     }
   end

--- a/spec/api/route/message_api_spec.rb
+++ b/spec/api/route/message_api_spec.rb
@@ -6,8 +6,8 @@ describe Route::MessageApi do
   describe 'GET /' do
     let(:response_keys) do
       [
-        "id", "body", "censored_at", "created_at", "deleted_at",
-        "in_reply_to_id", "status", "thread_id", "updated_at", "public_token"
+        "id", "body", "created_at",
+        "in_reply_to_id", "thread_id", "updated_at", "public_token"
       ]
     end
     let!(:resource) { create :message }

--- a/spec/api/route/thread_api_spec.rb
+++ b/spec/api/route/thread_api_spec.rb
@@ -7,7 +7,7 @@ describe Route::ThreadApi do
     let(:response_keys) do
       [
         "closed", "created_at", "created_by_id", "created_by_name",
-        "deleted_at", "group_id", "id", "issue_id", "privacy", "status", "updated_at", "public_token", "title"
+        "group_id", "id", "issue_id", "updated_at", "public_token", "title"
       ]
     end
     let!(:resource) { create :message_thread }


### PR DESCRIPTION
The API will not return censored or deleted or unapproved messages or threads so I don't think we need to expose these fields.

@PetrDlouhy I'm doing this as a PR to check it won't brake any of your integrations.

Also this makes the `created_by_name` always return a string